### PR TITLE
security(parser): close content-type desync + XML empty-parse body bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- Fixed a body-parser content-type desync bypass. `request_body_parser_type`
+  selected the parser with a case-insensitive *substring* match over the whole
+  `Content-Type` header, using sequential `if` blocks where the last match won.
+  A parser keyword smuggled into a parameter — e.g.
+  `application/json;charset=myxml` — matched "json" and then "xml" (inside
+  "myxml"), so Karna XML-parsed a JSON body while a backend read the base type
+  `application/json` and parsed it as JSON. The parser desync left the
+  arguments un-flattened, so a body attack (SQLi/XSS/…) skipped the rule
+  engine. On current code the exact payload was already blocked by the
+  always-on "deny what you can't inspect" body-parser gate (the misparse
+  errors out → 403), but the misclassification itself remained: it could
+  misroute legitimate bodies (false-positive 403s) and still desync via a
+  parser that never errors (urlencoded). Classification now keys off the base
+  media type only (the token before the first `;`/space), mirroring
+  `check_request_content_type_enforce`, with `elseif` ordering instead of
+  last-match-wins. Structured subtype suffixes (`+json`, `+xml`) are still
+  honoured. Reported by Davide Virruso (z3er01 @ zeronvll).
+- Deny XML-declared bodies that contain no XML elements. The SAX parser
+  (slaxml) accepts a tag-less payload — a JSON or plain-text body with no
+  `<...>` element — as a "successful" parse of an empty document: zero
+  elements, no error. The body-parser gate keys off a parse *error*, so such a
+  body slipped through with an empty argument set and was never inspected,
+  while a lenient backend (e.g. one that force-parses the body as JSON
+  regardless of `Content-Type`) still acted on it. A request with a valid
+  `Content-Type: application/xml` / `text/xml` and a JSON SQLi body was a full
+  bypass even after the content-type classification fix above. A non-whitespace
+  body declared as XML that yields no element is now treated as a parse failure
+  and blocked by the always-on body-parser gate. Genuine XML (including
+  attribute-only and self-closing elements) and empty/whitespace bodies are
+  unaffected. Verified with CRS PL1 regression at 2757/2757. Same report.
+
 ### Fixed
 
 - Wired the `@validateUrlEncoding` and `@validateUtf8Encoding` operators into

--- a/kong/plugins/karna/modules/ka_body_parser.lua
+++ b/kong/plugins/karna/modules/ka_body_parser.lua
@@ -614,6 +614,21 @@ _M.xml = function(self, prefix, raw_body, try_base64decode_if_possible)
     local parse_ok = pcall(function() parser:parse(raw_body,{stripWhitespace=true}) end)
     if parse_ok then
         self.debug("XML: parsing successful")
+        -- slaxml accepts a tag-less body (a JSON or plain-text payload with no
+        -- `<...>` element) as a "successful" parse of an empty document: it
+        -- opens zero elements and raises no error. That body yields an empty
+        -- argument set, so an attack hidden in it skips the rule engine — yet
+        -- a lenient backend (e.g. one that force-parses the body as JSON
+        -- regardless of Content-Type) still acts on it. That is the exact
+        -- parser desync the body-parser gate exists to stop. Treat a
+        -- non-whitespace body that produced no XML element as a parse failure
+        -- so check_request_body_parser blocks it — "deny what you can't
+        -- inspect". Whitespace-only / empty bodies carry no attack surface and
+        -- are left alone (slaxml already errors on a truly empty body).
+        if number_of_opened_elements == 0 and string_match(raw_body, "%S") then
+            self.debug("XML: parsed but found no elements — treating as unparseable")
+            return values, "xml parsing produced no elements"
+        end
     else
         -- Malformed XML declared as application/xml. slaxml only throws on
         -- genuinely broken structure (e.g. a raw `<` inside an attribute

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -111,20 +111,33 @@ _M.request_body_parser_type = function(self)
         -- as their real type instead of falling through to raw "text" (which
         -- let structured-arg attacks skip inspection — WAF bypass).
         content_type = content_type:lower()
-        if string.match(content_type, "json") then
-            request_body_type = "json"
-        end
 
-        if string.match(content_type, "multipart") then
-            request_body_type = "multipart"
-        end
-
-        if string.match(content_type, "www%-form%-urlencoded") then
-            request_body_type = "urlencoded"
-        end
-
-        if string.match(content_type, "xml") then
-            request_body_type = "xml"
+        -- Classify on the BASE media type only — the token before the first
+        -- `;` or whitespace — NOT a substring of the whole header. Substring
+        -- matching on the full value let a parser keyword smuggled into a
+        -- parameter reclassify the body: with sequential `if` blocks the LAST
+        -- match won, so `application/json;charset=myxml` matched "json" and
+        -- then "xml" (inside "myxml") and was XML-parsed. The XML parser
+        -- choked on the JSON body while the backend read base type
+        -- `application/json` and parsed it as JSON — a parser desync that
+        -- skipped argument inspection (body-parser bypass). Extracting the
+        -- base type mirrors check_request_content_type_enforce, and `elseif`
+        -- removes the "last match wins" footgun. Permissive structured
+        -- subtype suffixes (`+json`, `+xml`) are still honoured so
+        -- application/cloudevents+json, application/soap+xml et al. classify
+        -- correctly.
+        local base = string.match(content_type, "^%s*([^;%s]+)")
+        if base then
+            if base == "application/json" or string.match(base, "%+json$") then
+                request_body_type = "json"
+            elseif base == "text/xml" or base == "application/xml"
+                   or string.match(base, "%+xml$") then
+                request_body_type = "xml"
+            elseif base == "application/x-www-form-urlencoded" then
+                request_body_type = "urlencoded"
+            elseif string.match(base, "^multipart/") then
+                request_body_type = "multipart"
+            end
         end
     end
 


### PR DESCRIPTION
Two root causes from the same report (Davide Virruso, z3er01 @ zeronvll), both letting a body attack skip ARGS inspection.

## 1. Content-type selector desync (`ka_utils.lua`)
`request_body_parser_type` matched parser keywords as a **substring of the whole `Content-Type` header** with sequential `if` blocks (last-match-wins). `application/json;charset=myxml` matched `json` then `xml` (inside `myxml`) → a JSON body was XML-parsed while the backend read base type `application/json`. Now classifies off the **base media type** (token before the first `;`/space), with `elseif` ordering; `+json` / `+xml` subtype suffixes preserved. Mirrors `check_request_content_type_enforce`.

## 2. XML empty-parse slips the deny-gate (`ka_body_parser.lua`)
slaxml accepts a **tag-less body** (JSON/text, no element) as a *successful* parse of an empty document — zero elements, no error. The "deny what you can't inspect" gate keys off a parse **error**, so the body passed with an empty argument set: neither inspected nor denied. A valid `Content-Type: application/xml` / `text/xml` + JSON SQLi body was a **full bypass against a force-JSON-parsing backend even after fix #1**. A non-whitespace XML-declared body that yields no element is now treated as a parse failure and blocked. Genuine XML (incl. attribute-only / self-closing) and empty/whitespace bodies are unaffected.

## Verification (DEV stack, PL1, blocking)
| case | before | after |
|---|---|---|
| `application/json;charset=myxml` + SQLi (PoC) | 200 | 403 (942100) |
| `application/xml` + JSON SQLi | 200 | 403 (body-parser gate) |
| `text/xml` + JSON SQLi | 200 | 403 |
| `application/json;charset=x-www-form-urlencoded` + SQLi | 200 | 403 (942100) |
| benign XML / attr-SQLi / empty body | 200 / 403 / 200 | unchanged |
| **CRS PL1 regression** | 2757/2757 | **2757/2757** (empty-diff) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)