### PR TITLE
security(parser): inspect top-level JSON scalar request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- Inspect top-level JSON scalar request bodies. A body that decodes to a bare
+  JSON scalar — a string, number, or boolean (e.g. `"' OR '1'='1"`) — has no
+  object or array to flatten, so the value never reached ARGS and slipped past
+  the rule engine, while a lenient backend that re-parses the body as form data
+  still acted on it (the JSON content-type-confusion bypass from terjanq's
+  WAF-bypass write-up). The body parsed cleanly, so the always-on body-parser
+  gate didn't catch it either — the JSON twin of the XML empty-document gap
+  closed in 1.1.2. The scalar is now surfaced as a single argument value and
+  inspected like any other parameter. Benign scalar bodies (`"hello"`, `123`)
+  are unaffected. Verified with CRS PL1 regression at 2757/2757.
+
 ## [1.1.2] - 2026-06-10
 
 ### Security

--- a/kong/plugins/karna/modules/ka_body_parser.lua
+++ b/kong/plugins/karna/modules/ka_body_parser.lua
@@ -278,6 +278,15 @@ _M.json = function(self, prefix, raw_json, try_base64decode_if_possible)
             end
         else
             flatTable[parentKey] = t
+            -- Top-level JSON scalar (body is a bare `"..."`, number, or bool,
+            -- e.g. `"' OR '1'='1"`): there is no object/array to flatten, so
+            -- the value never reached ARGS and slipped past the rule engine —
+            -- while a lenient backend that re-parses the body as form data acts
+            -- on it (terjanq JSON content-type-confusion bypass). The body
+            -- parsed cleanly, so the "deny what you can't inspect" gate didn't
+            -- fire either. Surface the scalar as a single ARGS value (mirroring
+            -- the XML empty-document fix) so detection rules inspect it.
+            insert_new_value((prefix .. ".value:0"):lower(), tostring(t))
         end
 
         return true, nil


### PR DESCRIPTION
Closes the JSON content-type-confusion bypass from [terjanq's WAF-bypass write-up](https://terjanq.medium.com/waf-bypasses-via-0days-d4ef1f212ec) (#2 in that article). The JSON twin of the XML empty-document gap closed in v1.1.2.

## Root cause
`body_parser:json` → `flattenTable` only populates the returned `values` table inside its table branch (via `insert_new_value`). When the decoded JSON is a **bare scalar** (string / number / boolean), the `else` branch wrote only to a throwaway local accumulator. So a body like `"' OR '1'='1"`:
- decodes cleanly → no parse error → the "deny what you can't inspect" gate doesn't fire
- produces **zero ARGS** → the rule engine has nothing to scan → request passes (200)

A lenient backend that re-parses the body as form data (e.g. Express / Juice Shop in the article) then acts on the injection.

## Fix
Surface the top-level scalar as a single argument value so detection rules inspect it, mirroring the XML empty-document fix.

## Verification (DEV stack, PL1, blocking)
| case | before | after |
|---|---|---|
| `"' OR '1'='1"` | 200 | 403 (942100) |
| `"&email='or 1--"` | 200 | 403 (942100) |
| benign `"hello"` / `123` | 200 | 200 (no FP) |
| normal JSON object + SQLi | 403 | 403 (no regression) |
| **CRS PL1 regression** | 2757/2757 | **2757/2757** (empty-diff) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)