### PR TITLE
release: v1.1.4 — multipart parser fixes (bodyless part + framing-scoped CRLF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-06-11
+
 ### Fixed
 
 - Stop rejecting legitimate file uploads that contain Unix (LF) newlines. The
@@ -251,7 +253,8 @@ Core Rule Set. It needs no other plugin to work.
   inspected by default (set it to `true` to bypass trusted internal ranges).
 - The PL1 OWASP CRS regression suite passes at 100%.
 
-[Unreleased]: https://github.com/sicuranext/karna/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/sicuranext/karna/compare/v1.1.4...HEAD
+[1.1.4]: https://github.com/sicuranext/karna/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/sicuranext/karna/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/sicuranext/karna/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/sicuranext/karna/compare/v1.1.0...v1.1.1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.1.3-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.1.4-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.1.3",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.1.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.1.3-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.1.3-0.rockspec:ro
+      - ../kong-plugin-karna-1.1.4-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.1.4-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
 
     command: >

--- a/kong-plugin-karna-1.1.4-0.rockspec
+++ b/kong-plugin-karna-1.1.4-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.1.3-0"
+version = "1.1.4-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.1.3"
+  tag = "v1.1.4"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.1.3",
+  VERSION = "1.1.4",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.1.3",
+  version      = "1.1.4",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.1.3",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.1.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
Version bump for the two multipart-parser fixes that landed in #6 / 84edf5d:

- **Security** — reject malformed parts with no body section (terjanq #3 empty-part desync)
- **Fix** — scope strict-CRLF to framing so legitimate text-file uploads (Unix `\n` newlines) are no longer false-positived (was 403)

Release plumbing only (no behavior change):
- `version.lua` → `1.1.4`; `handler.lua` `VERSION` → `1.1.4`
- rockspec renamed `…-1.1.3-0` → `…-1.1.4-0`; `version = "1.1.4-0"`, `tag = "v1.1.4"`
- `docker/Dockerfile`, `docker/docker-compose.dev.yml`, `scripts/install.sh` version refs aligned
- `CHANGELOG.md`: finalised `[1.1.4] - 2026-06-11`, fresh empty `[Unreleased]`, link-refs updated

Three version sources verified in sync; no stray `1.1.3` refs outside CHANGELOG history; Lua syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)