### PR TITLE
security(parser): harden against BackBox AI assessment — XML DoS + JSON sanitize corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
         run: lua ka-unittest/seclang_ctl_directives.lua
       - name: fix_matched_parts action (sanitize-not-block primitive)
         run: lua ka-unittest/fix_matched_parts.lua
+      - name: JSON per-field sanitisation (fix_matched_parts, structure preserved)
+        run: lua ka-unittest/json_sanitize_field.lua
       - name: rule_action_overrides / rule_response_overrides (config-level)
         run: lua ka-unittest/rule_overrides.lua
       - name: Op negation normalization (canonical vs legacy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- Cap XML nesting depth to stop a quadratic-parser DoS. The XML body flatten
+  rebuilds the element path string on every open and close, and the path grows
+  with depth, so a deeply-nested document costs O(depth²): a ~56 KB body
+  (8000 levels) burned ~2.6s of worker CPU, and the request-argument DoS gate
+  never caught it (XML keys aren't shaped like ARGS). Nesting beyond 256 levels
+  — far past any SOAP / SAML / config document — now aborts the parse from
+  inside the SAX callback, so the always-on body-parser gate rejects the
+  request (403) in a few milliseconds instead of grinding. Genuine shallow XML
+  is unaffected. Reported by BackBox AI (https://backbox.dev).
+
+### Fixed
+
+- Sanitise JSON request bodies per-field instead of mangling the whole
+  document. The `fix_matched_parts` action ("sanitize-not-block") raw-stripped
+  the entire body for a JSON match, deleting every structural `"` and
+  unconditionally removing `%` / `\`, which corrupted unrelated, legitimate
+  fields and handed the upstream malformed JSON. It now parses the body, cleans
+  only the matched field's value in place, and re-serialises — so the structure
+  and the other fields survive. Unresolvable key paths fall back to the prior
+  raw-strip (the attack is still neutralised). Reported by BackBox AI
+  (https://backbox.dev).
+
 ## [1.1.4] - 2026-06-11
 
 ### Fixed

--- a/ka-unittest/json_sanitize_field.lua
+++ b/ka-unittest/json_sanitize_field.lua
@@ -1,0 +1,109 @@
+-- ka-unittest/json_sanitize_field.lua
+--
+-- Unit-test the per-field JSON sanitisation used by the `fix_matched_parts`
+-- action (the "sanitize-not-block" primitive). When a sanitize rule matches a
+-- value inside a JSON body, Karna must clean ONLY that field's value and leave
+-- the rest of the document — structure and the other, legitimate fields —
+-- intact. The previous code raw-stripped the whole JSON body, deleting every
+-- `"` and unconditionally removing `%` / `\`, which corrupted unrelated fields
+-- and produced malformed JSON for the upstream (reported by BackBox AI,
+-- https://backbox.dev).
+--
+-- We replicate the path-walk + clean logic inline (cjson isn't available in the
+-- plain CI Lua sandbox, and the risk lives entirely in resolving the flattened
+-- key path against the decoded table — the decode/encode themselves are
+-- cjson's job). KEEP IN SYNC with kong/plugins/karna/modules/ka_engine.lua →
+-- _M.__fix_matching_parts (the _ue_clean / _json_clean_field helpers).
+--
+-- Run from repo root:
+--   lua ka-unittest/json_sanitize_field.lua
+
+local string_gsub, string_gmatch = string.gsub, string.gmatch
+
+-- Mirror of the engine's _ue_clean + _json_clean_field (operating on a decoded
+-- table, exactly as the real code does after cjson_safe.decode).
+local function make_cleaner(remove_pattern)
+    local function _ue_clean(s)
+        if type(s) ~= "string" then return s end
+        s = string_gsub(s, "%%", "")
+        s = string_gsub(s, "\\", "")
+        return (string_gsub(s, remove_pattern, ""))
+    end
+    return function(json_body, path)
+        if type(json_body) ~= "table" then return false end
+        local function clean_leaf(node, key)
+            if type(node[key]) == "string" then
+                node[key] = _ue_clean(node[key])
+                return true
+            end
+            return false
+        end
+        if json_body[path] ~= nil and clean_leaf(json_body, path) then return true end
+        local segs = {}
+        for s in string_gmatch(path, "[^.]+") do segs[#segs + 1] = s end
+        if #segs == 0 then return false end
+        local node = json_body
+        for i = 1, #segs - 1 do
+            local nxt = node[segs[i]]
+            if nxt == nil then
+                local nk = tonumber(segs[i])
+                if nk ~= nil then nxt = node[nk] end
+            end
+            if type(nxt) ~= "table" then return false end
+            node = nxt
+        end
+        local leaf = segs[#segs]
+        if node[leaf] ~= nil then return clean_leaf(node, leaf) end
+        local n = tonumber(leaf)
+        if n ~= nil and node[n] ~= nil then return clean_leaf(node, n) end
+        return false
+    end
+end
+
+local clean = make_cleaner('["\']')
+local pass, fail = 0, 0
+local function eq(got, want, msg)
+    if got == want then
+        pass = pass + 1
+        print("  ok  - " .. msg)
+    else
+        fail = fail + 1
+        print("  FAIL- " .. msg .. "  got=" .. tostring(got) .. " want=" .. tostring(want))
+    end
+end
+
+-- 1) top-level: only the matched field is cleaned; siblings (including a value
+--    that legitimately contains % and \) are left exactly as-is.
+local t1 = { q = "x'y\"z", keep = "50% off \\ ok", note = "a;b;c" }
+eq(clean(t1, "q"), true, "top-level matched field returns true")
+eq(t1.q, "xyz", "matched field cleaned")
+eq(t1.keep, "50% off \\ ok", "sibling with % and \\ left untouched")
+eq(t1.note, "a;b;c", "other sibling untouched")
+
+-- 2) nested object field via dotted path
+local t2 = { user = { name = "o'brien", id = "42" } }
+eq(clean(t2, "user.name"), true, "nested field returns true")
+eq(t2.user.name, "obrien", "nested field cleaned")
+eq(t2.user.id, "42", "nested sibling untouched")
+
+-- 3) array element (cjson decodes JSON arrays to 1-indexed Lua tables)
+local t3 = { items = { "a'x", "b'y" } }
+eq(clean(t3, "items.1"), true, "array element returns true")
+eq(t3.items[1], "ax", "array element cleaned")
+eq(t3.items[2], "b'y", "array sibling untouched")
+
+-- 4) unresolvable paths return false so the caller falls back to the raw-strip
+--    (the attack is still neutralised, just not per-field)
+eq(clean({ x = "y" }, "missing"), false, "missing key -> false (fallback)")
+eq(clean({ a = { b = 1 } }, "a.b.c"), false, "over-deep path -> false (fallback)")
+
+-- 5) a top-level key that itself contains dots (whole-path-as-key branch)
+local t5 = { ["a.b"] = "z'z" }
+eq(clean(t5, "a.b"), true, "dotted top-level key returns true")
+eq(t5["a.b"], "zz", "dotted top-level key cleaned")
+
+-- 6) non-string leaf (number / object) -> false (fallback, never coerces)
+eq(clean({ n = 5 }, "n"), false, "numeric leaf -> false (fallback)")
+
+print(string.format("\n%d passed, %d failed", pass, fail))
+os.exit(fail == 0 and 0 or 1)

--- a/kong/plugins/karna/modules/ka_body_parser.lua
+++ b/kong/plugins/karna/modules/ka_body_parser.lua
@@ -486,12 +486,32 @@ _M.xml = function(self, prefix, raw_body, try_base64decode_if_possible)
     local prefix_path_attr_name = "request.body.xml.attr.name.%NOOE%:"
     local root_element = true
     local number_of_opened_elements = 0
+    -- Cap XML nesting depth. The flatten rebuilds the element path string on
+    -- every open/close (replace_nooe on startElement, the gsub on
+    -- closeElement), and the path length grows with depth, so a deeply-nested
+    -- document costs O(depth^2): a small body (tens of KB) can burn seconds of
+    -- worker CPU — an algorithmic-complexity DoS (reported by BackBox AI,
+    -- https://backbox.dev). The arg-count gate doesn't catch it (XML keys
+    -- aren't shaped like ARGS). Legit XML is shallow; 256 is far beyond
+    -- SOAP / SAML / config depths. Exceeding it aborts the parse from inside
+    -- the SAX callback so the body-parser gate rejects the request instead of
+    -- grinding.
+    local XML_MAX_DEPTH = 256
+    local current_depth = 0
+    local xml_too_deep = false
     local SLAXML = require 'kong.plugins.karna.slaxml'
     
     local parser = SLAXML:parser {
         -- When "<foo" or <x:foo is seen
         startElement = function(name,nsURI,nsPrefix)
             number_of_opened_elements = number_of_opened_elements + 1
+            current_depth = current_depth + 1
+            if current_depth > XML_MAX_DEPTH then
+                -- Abort immediately: stops the O(depth^2) path rebuilding before
+                -- it can grind. parse_ok becomes false -> rejected below.
+                xml_too_deep = true
+                error("xml nesting depth exceeds limit")
+            end
             self.debug("XML: startElement ".. tostring(number_of_opened_elements) .." name: " .. name)
             if nsURI then self.debug("startElement nsURI: " .. nsURI) end
             if nsPrefix then self.debug("startElement nsPrefix: " .. nsPrefix) end
@@ -541,6 +561,7 @@ _M.xml = function(self, prefix, raw_body, try_base64decode_if_possible)
         end,
         -- When "</foo>" or </x:foo> or "/>" is seen
         closeElement = function(name,nsURI)
+            current_depth = current_depth - 1
             self.debug("closeElement name: " .. name)
             if nsURI then self.debug("closeElement nsURI: " .. nsURI) end
 
@@ -639,6 +660,10 @@ _M.xml = function(self, prefix, raw_body, try_base64decode_if_possible)
             return values, "xml parsing produced no elements"
         end
     else
+        if xml_too_deep then
+            self.debug("XML: nesting depth exceeded limit")
+            return values, "xml nesting depth exceeds limit"
+        end
         -- Malformed XML declared as application/xml. slaxml only throws on
         -- genuinely broken structure (e.g. a raw `<` inside an attribute
         -- value, which conformant backends reject too). Surface it as an

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -5216,6 +5216,61 @@ _M.__fix_matching_parts = function(self, rule, matched_parts)
         s = string_gsub(s, "\\", "")
         return (string_gsub(s, rule.action.fix_matched_parts.remove_chars_pattern, ""))
     end
+
+    -- JSON body: sanitise per-field, like urlencoded. Parse once, clean only
+    -- the matched field's value in place, re-serialise at the end. The old code
+    -- raw-stripped the whole JSON body, which deleted structural characters
+    -- (every `"`, etc.) and handed the upstream malformed JSON, corrupting the
+    -- other, legitimate fields and breaking the document (reported by BackBox
+    -- AI, https://backbox.dev). json_body: nil = not tried, false = parse
+    -- failed (fall back to the raw-strip).
+    local json_body
+    local json_dirty = false
+    -- Walk the flattened key path (e.g. "user.name", "items.1.x") to the matched
+    -- leaf and clean its string value. Returns true only on a clean per-field
+    -- edit; false tells the caller to fall back to the raw-strip (a key that
+    -- itself contains dots, or other ambiguous shapes, can't be resolved from
+    -- the flattened path — the attack is still neutralised by the fallback).
+    local function _json_clean_field(path)
+        if type(json_body) ~= "table" then return false end
+        local function clean_leaf(node, key)
+            if type(node[key]) == "string" then node[key] = _ue_clean(node[key]); return true end
+            return false
+        end
+        -- Whole path as a single top-level key first (handles a top-level key
+        -- that itself contains dots).
+        if json_body[path] ~= nil and clean_leaf(json_body, path) then return true end
+        local segs = {}
+        for s in string_gmatch(path, "[^.]+") do segs[#segs + 1] = s end
+        if #segs == 0 then return false end
+        local node = json_body
+        for i = 1, #segs - 1 do
+            local nxt = node[segs[i]]
+            if nxt == nil then
+                local nk = tonumber(segs[i])
+                if nk ~= nil then nxt = node[nk] end
+            end
+            if type(nxt) ~= "table" then return false end
+            node = nxt
+        end
+        local leaf = segs[#segs]
+        if node[leaf] ~= nil then return clean_leaf(node, leaf) end
+        local n = tonumber(leaf)
+        if n ~= nil and node[n] ~= nil then return clean_leaf(node, n) end
+        return false
+    end
+    local function _try_json_field(path)
+        if json_body == nil then
+            local raw = request_get_raw_body()
+            json_body = (raw and cjson_safe.decode(raw)) or false
+        end
+        if _json_clean_field(path) then
+            json_dirty = true
+            return true
+        end
+        return false
+    end
+
     for _,mp in pairs(matched_parts) do
         --inspect(mp)
 
@@ -5268,6 +5323,7 @@ _M.__fix_matching_parts = function(self, rule, matched_parts)
         -- which includes the name key, and pairs() order is non-deterministic,
         -- so matched_on can be either. Either way the target field is the same.
         local ub = string_match(mp.matched_on, '^request%.body%.urlencode%.[^:]+:(.+)$')
+        local jb = string_match(mp.matched_on, '^request%.body%.json%.value%:(.+)$')
         if ub then
             if ue_body == nil then
                 ue_body = kong.request.get_body("application/x-www-form-urlencoded") or false
@@ -5286,6 +5342,12 @@ _M.__fix_matching_parts = function(self, rule, matched_parts)
         -- generic body (scalar request.body, or json / multipart / xml):
         -- raw-string strip on the whole body. Structured per-field
         -- sanitisation currently covers urlencoded only.
+        -- JSON body field: clean only the matched field's value and re-serialise
+        -- (below), so the rest of the document survives. Falls through to the
+        -- raw-strip if the field can't be resolved from the flattened path.
+        elseif jb and _try_json_field(jb) then
+            debug("Fixing matched part (json per-field): " .. mp.matched_on)
+
         elseif string_match(mp.matched_on, '^request%.body') then
             local body = request_get_raw_body()
             -- body buffered to disk (large body, incl. large chunked): read it
@@ -5314,6 +5376,15 @@ _M.__fix_matching_parts = function(self, rule, matched_parts)
     -- write winning when several form fields matched).
     if ue_dirty and type(ue_body) == "table" then
         kong.service.request.set_body(ue_body, "application/x-www-form-urlencoded")
+    end
+    -- One re-serialise for all sanitized JSON fields, preserving structure.
+    if json_dirty and type(json_body) == "table" then
+        local encoded = cjson_safe.encode(json_body)
+        if encoded then
+            kong.service.request.set_raw_body(encoded)
+        else
+            debug("json re-encode failed after sanitise; body left unmodified")
+        end
     end
 end
 


### PR DESCRIPTION
Two issues from a [BackBox AI](https://backbox.dev) white-box assessment of Karna, reported privately.

## 1. Security — quadratic XML parser DoS
The XML body flatten rebuilds the element path string on every open/close, and the path length grows with nesting depth, so a deeply-nested document costs **O(depth²)**:

| body | depth | CPU (before) |
|---|---|---|
| 14 KB | 2000 | 0.18s |
| 28 KB | 4000 | 0.63s |
| 56 KB | 8000 | **2.6s** |

Unauthenticated, and the request-arg-count DoS gate doesn't catch it (XML keys aren't shaped like ARGS). Nesting beyond **256 levels** (far past any SOAP/SAML/config document) now aborts the parse from inside the SAX callback, so the always-on body-parser gate rejects the request (403) in ~4ms. Shallow XML is unaffected.

## 2. Fix — sanitize action corrupts valid JSON
`fix_matched_parts` raw-stripped the **whole** JSON body on a match, deleting every structural `"` and unconditionally removing `%` / `\` — corrupting unrelated, legitimate fields and handing the upstream malformed JSON. It now parses the body, cleans **only the matched field's value** in place (mirroring the existing urlencoded per-field path), and re-serialises. Unresolvable key paths fall back to the prior raw-strip so the attack is still neutralised. New unit test `ka-unittest/json_sanitize_field.lua` (wired into CI) covers the path-walk.

## Verification (DEV stack, PL1, blocking)
| case | result |
|---|---|
| XML depth > 256 | 403 in ~4ms (was up to 2.6s) |
| XML depth ≤ 256 / shallow XML | 200, inspected |
| XML attribute SQLi | 403 (942100) — detection intact |
| JSON sanitize: matched field cleaned, siblings + structure intact | 15/15 unit asserts |
| existing fix_matched_parts unit test | green |
| **CRS PL1 regression** | **2757/2757** (empty-diff) |

Credit: both reported by **BackBox AI (backbox.dev)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)