### PR TITLE
ci: harden Karna activation wait against config-propagation flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch: # allow manual re-runs (e.g. after a transient CI flake)
 
 # Least privilege. GitHub's default GITHUB_TOKEN can be read/write; these jobs
 # only need to read the repo. (The real guard against PR abuse is the repo
@@ -148,15 +149,29 @@ jobs:
       - name: Wait for Karna to activate (Postgres config propagation)
         run: |
           set -e
+          base='http://localhost:28000/'
           attack='http://localhost:28000/?q=1%27%20OR%20%271%27=%271'
-          for i in $(seq 1 30); do
-            if [ "$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: karna-test' "$attack")" = "403" ]; then
+          hdr='Host: karna-test'
+          # 1) Wait for the proxy + route to serve at all (any non-000 status).
+          #    On a busy runner the proxy listener can lag the admin API.
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -H "$hdr" "$base" || true)
+            [ -n "$code" ] && [ "$code" != "000" ] && { echo "proxy serving after ${i}s (code ${code})"; break; }
+            sleep 1
+          done
+          # 2) Wait for Karna to actually block the attack (DB-mode config
+          #    propagation polls every db_update_frequency, ~5s; allow ample margin).
+          for i in $(seq 1 60); do
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' -H "$hdr" "$attack")" = "403" ]; then
               echo "Karna active after ${i} polls"; break
             fi
             sleep 2
           done
-          test "$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: karna-test' "$attack")" = "403" \
-            || { echo "::error::Karna did not activate (config propagation); WAF not blocking"; exit 1; }
+          if [ "$(curl -s -o /dev/null -w '%{http_code}' -H "$hdr" "$attack")" != "403" ]; then
+            echo "benign=$(curl -s -o /dev/null -w '%{http_code}' -H "$hdr" "$base") attack=$(curl -s -o /dev/null -w '%{http_code}' -H "$hdr" "$attack")"
+            echo "::error::Karna did not activate (config propagation); WAF not blocking"
+            exit 1
+          fi
 
       - name: Run CRS PL1 regression with pass-rate floor
         run: |


### PR DESCRIPTION
## What

The `main` CI run for the **v1.1.5** release failed at the **"Wait for Karna to activate"** step — not a code regression. The same commit passed on its PR run, every other recent `main` push is green, and the actual test steps (CRS PL1 regression, sanitize, overrides, rate-limit) never ran.

The step polled ~60s for the WAF to start blocking a probe SQLi, then failed. In DB mode (Postgres) Kong propagates plugin config to workers on a poll cycle (`db_update_frequency`, ~5s); on a busy runner the full bring-up + propagation occasionally exceeds the 60s budget → timeout flake.

## Changes (`.github/workflows/ci.yml` only)

- **Wait for the proxy listener first** (up to 60s) — it can lag the admin API that the previous step already waited on — then allow **up to ~120s** for Karna to block the probe (was ~60s).
- **Dump benign/attack status codes on failure** so a real failure is diagnosable vs a timing one.
- **Add `workflow_dispatch`** so a transient flake can be re-run manually (the old run was too old for `gh run rerun`, and there was no manual trigger).

No engine/rule changes. Scope is the CI workflow only.