### PR TITLE
feat: audit log v2 response.latencies breakdown (total / upstream / kong)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Audit log v2 now records a `response.latencies` breakdown in milliseconds —
+  `total` (the whole request, from nginx `$request_time`), `upstream` (time
+  waiting for the upstream, the existing `latency_ms`), and `kong` (the
+  gateway's own processing: Karna plus any other plugins and the proxy, i.e.
+  total minus upstream, clamped at zero). The values are read from the nginx
+  timers in the `log` phase, so no earlier phase is touched and there is no
+  added request-path cost. This makes the WAF/gateway processing time visible
+  to log consumers (SIEM, log pipelines) without an external timing source; the
+  pre-existing `response.latency_ms` is unchanged for backward compatibility.
+
 ### Security
 
 - `rule_response_overrides` no longer resolves `%{var}` macros in the response

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -567,6 +567,27 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
     end
     latency_ms = latency_ms or 0
 
+    -- request-level latency breakdown (ms), read from the nginx timers in the
+    -- log phase — no extra instrumentation in the earlier phases:
+    --   total    = the whole request          ($request_time)
+    --   upstream = time waiting for upstream   (latency_ms, computed above)
+    --   kong     = the gateway's own processing (Karna + other plugins + proxy)
+    --              i.e. total minus upstream, clamped at zero
+    local total_ms
+    local rt = tonumber(tostring(ngx.var.request_time or ""):match("^[^,]+"))
+    if rt then total_ms = rt * 1000 end
+    local kong_ms
+    if total_ms then
+        kong_ms = total_ms - latency_ms
+        if kong_ms < 0 then kong_ms = 0 end
+    end
+    local function _round2(n) return n and tonumber(string.format("%.2f", n)) or 0 end
+    local latencies = {
+        total = _round2(total_ms),
+        upstream = _round2(latency_ms),
+        kong = _round2(kong_ms)
+    }
+
     -- collect sibling-plugin log entries (external_matches), if any
     local raw_external = nil
     if kong.ctx.shared.karna and kong.ctx.shared.karna.log_entries then
@@ -602,7 +623,8 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
         response = {
             status = kong.response.get_status(),
             headers = response_headers,
-            latency_ms = latency_ms
+            latency_ms = latency_ms,
+            latencies = latencies
         },
         engine = {
             name = "karna",


### PR DESCRIPTION
## What

Audit log v2 now records a `response.latencies` block (milliseconds) alongside the existing `response.latency_ms`:

```json
"response": {
  "status": 403,
  "latency_ms": 12.4,
  "latencies": { "total": 18.7, "upstream": 12.4, "kong": 6.3 }
}
```

- `total` — the whole request, from nginx `$request_time`
- `upstream` — time waiting for the upstream (the existing `latency_ms`: `x-karna-upstream-latency` header, else `$upstream_response_time`)
- `kong` — `total - upstream`, clamped at zero — the gateway's own processing (Karna, other plugins, the proxy)

## Why

Gives log consumers (SIEM, log pipelines) the gateway/WAF processing time directly, without an external timing source.

## Scope / safety

- Read entirely from the nginx timers in the **`log` phase** — no earlier phase is touched, no added request-path cost.
- `response.latency_ms` is unchanged (backward compatible); `latencies` is additive.
- Values rounded to 2 decimals; missing timers degrade to `0`.

CHANGELOG `Unreleased / Added` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)