### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-06-19
+
 ### Added
 
 - Audit log v2 now records a `response.latencies` breakdown in milliseconds —

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.1.5-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.2.0-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.1.5",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.2.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.1.5-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.1.5-0.rockspec:ro
+      - ../kong-plugin-karna-1.2.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.2.0-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
 
     command: >

--- a/kong-plugin-karna-1.2.0-0.rockspec
+++ b/kong-plugin-karna-1.2.0-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.1.5-0"
+version = "1.2.0-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.1.5"
+  tag = "v1.2.0"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.1.5",
+  VERSION = "1.2.0",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.1.5",
+  version      = "1.2.0",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.1.5",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.2.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
## v1.2.0

Minor release bundling the two changes merged since 1.1.5.

### Changes

- **security (#11)** — `rule_response_overrides` no longer resolves `%{var}` macros in the response `body`. The body was reflected to the client in Karna's own block response, so request-derived macros (`%{request.path}`, `%{request.host}`) were a reflected-XSS sink when served as HTML. The body is now served verbatim as the operator-authored static string.
- **feat (#12)** — Audit log v2 gains a `response.latencies` breakdown (`total` / `upstream` / `kong`) in milliseconds, read from the nginx timers in the `log` phase. Additive; `response.latency_ms` unchanged.

### Version sync

- `kong/plugins/karna/version.lua` → `1.2.0`
- `handler.lua` `plugin.VERSION` → `1.2.0`
- rockspec renamed `kong-plugin-karna-1.1.5-0` → `1.2.0-0` (`version` + `tag`)
- `docker/Dockerfile`, `docker/docker-compose.dev.yml`, `scripts/install.sh` rockspec/stamp references
- CHANGELOG `Unreleased` entries moved under `## [1.2.0] - 2026-06-19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)