### PR TITLE
auditlog: trailing newline on file records (JSON Lines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Audit log files now end with a trailing newline. Each record was already a
+  single physical line (embedded CR/LF are stripped); terminating it with a
+  newline makes the output valid JSON Lines (NDJSON), so log collectors that
+  split on newline and parse one object per line — Filebeat, Fluent Bit,
+  Vector, Promtail — ingest the files without extra configuration. The record
+  content is otherwise unchanged.
+
 ## [1.2.0] - 2026-06-19
 
 ### Added

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -654,8 +654,12 @@ _M.write_auditlog = function(premature, json_log, auditlog_path, timestamp, requ
     kong.log.debug("Karna: writing audit log to file: ", filename)
     local file = io.open(filename, "w")
     if file then
+        -- Strip any embedded CR/LF so the record is a single physical line,
+        -- then terminate it with one trailing newline. This is the JSON Lines
+        -- (NDJSON) convention log collectors expect — Filebeat / Fluent Bit /
+        -- Vector / Promtail split on newline and parse one object per line.
         local json_log_no_newlines = cjson.encode(json_log):gsub("[\r\n]","")
-        file:write(json_log_no_newlines)
+        file:write(json_log_no_newlines, "\n")
         file:close()
     else
         kong.log.err("Karna: failed to write audit log to file: ", filename)


### PR DESCRIPTION
## What

Audit log files now end with a trailing `\n`.

## Why

Each file holds one audit record, already collapsed to a single physical line (embedded CR/LF are stripped). Terminating it with a newline makes the output valid **JSON Lines (NDJSON)** — log collectors that split on newline and parse one object per line (Filebeat, Fluent Bit, Vector, Promtail) ingest the files without extra configuration.

## Scope

- Single line in `ka_utils.lua:write_auditlog` (`file:write(..., "\n")`).
- Record content is unchanged; only a trailing newline is added.
- Confined to the `log`-phase file writer — inert for detection (CRS regression stays empty-diff).

CHANGELOG `Unreleased / Changed` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)