### PR TITLE
fix(engine): guard response Set-Cookie inspection against string values (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-26
+
+### Fixed
+
+- `header_filter` no longer crashes when an upstream response carries a
+  `Set-Cookie` header whose value flattens to a plain string (e.g.
+  `PHPSESSID=abc123; path=/`). The response-cookie inspection loop assumed
+  every flattened value was a table and called `pairs()` on it, which aborted
+  the response phase ("upstream sent no response") for any cookie-setting
+  backend (WordPress, PHP sessions, and the like). The value is still added to
+  the inspection table, so response-rule detection is unchanged.
+
 ### Changed
 
 - Audit log files now end with a trailing newline. Each record was already a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.2.0-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.2.1-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.2.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.2.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.2.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.2.0-0.rockspec:ro
+      - ../kong-plugin-karna-1.2.1-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.2.1-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
 
     command: >

--- a/kong-plugin-karna-1.2.1-0.rockspec
+++ b/kong-plugin-karna-1.2.1-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.2.0-0"
+version = "1.2.1-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.2.0"
+  tag = "v1.2.1"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.2.0",
+  VERSION = "1.2.1",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -4492,12 +4492,19 @@ _M.get_inspection_table = function(self, plugin_conf)
             for k,v in pairs(cookie_flattened) do
                 local value_is_json = false
 
-                for ckeyn,cval in pairs(v) do
-                    if pcall(cjson.decode,cval) then
-                        value_is_json = true
-                        local cookie_json_flat = body_parser:json("response.set_cookie", cval, plugin_conf.try_bas64decode_if_possible)
-                        for kk,vv in pairs(cookie_json_flat) do
-                            table_insert(kong.ctx.plugin.inspection_table, vv)
+                -- A Set-Cookie value can flatten to a plain string (e.g.
+                -- `PHPSESSID=abc; path=/`) rather than a table. Guard pairs()
+                -- so a cookie-setting upstream (WordPress, PHP sessions, …)
+                -- cannot crash header_filter. The string value is still pushed
+                -- into the inspection table below, so detection is unchanged.
+                if type(v) == "table" then
+                    for ckeyn,cval in pairs(v) do
+                        if pcall(cjson.decode,cval) then
+                            value_is_json = true
+                            local cookie_json_flat = body_parser:json("response.set_cookie", cval, plugin_conf.try_bas64decode_if_possible)
+                            for kk,vv in pairs(cookie_json_flat) do
+                                table_insert(kong.ctx.plugin.inspection_table, vv)
+                            end
                         end
                     end
                 end

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.2.0",
+  version      = "1.2.1",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.2.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.2.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
## Summary
Fixes a `header_filter` crash that returned an empty reply for any cookie-setting upstream.

`get_inspection_table` parses response `Set-Cookie` headers and called `pairs(v)` assuming every flattened cookie value is a table. A simple cookie like `Set-Cookie: PHPSESSID=abc; path=/` flattens to a plain string, so `pairs(string)` aborted the response phase — Kong returned an empty reply for any backend that sets a session cookie (WordPress, PHP, most apps). Guarded with a `type(v) == "table"` check; the string value is still added to the inspection table, so response-rule detection is unchanged.

Surfaced while putting Kong + Karna in front of a real WordPress + AI Engine chatbot.

## Release
**v1.2.1** — bumps `version.lua`, `handler.lua`, the renamed rockspec (`1.2.0-0` → `1.2.1-0`), and the Docker + `install.sh` build stampers.

## Testing
- CRS PL1 regression: **2757/2757 (100%)**, empty-diff vs baseline (the fix is response-phase only; request detection unchanged).
- End-to-end: WordPress + AI Engine behind Kong — benign chatbot POST now **200** (was empty reply); attack payload still blocked **403**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)