### PR TITLE
feat(auditlog): rotate audit log per worker per minute (JSON Lines)

### DIFF
--- a/.claude/skills/karna/reference/recipes.md
+++ b/.claude/skills/karna/reference/recipes.md
@@ -126,7 +126,11 @@ grep -E 'Passed tests:' regression.log
 A drop in the pass count is a regression — investigate before shipping.
 
 ## Read the audit log
-Default `auditlog_path`: `/usr/local/openresty/nginx/logs`. v2 format = one JSON
+Default `auditlog_path`: `/usr/local/openresty/nginx/logs`. Karna writes JSON
+Lines, one file per worker per minute named
+`karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl` (UTC minute), appending one
+record per line. To watch live, tail the newest file, e.g.
+`tail -F "$(ls -t karna_auditlog_*.jsonl | head -1)"`. v2 format = one JSON
 entry per request with all matches in a `matches` array. `action` values to look
 for: `"blocked"`, `"sanitized"`, `"rate_limited"`, `"log"`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- Audit log files are now written one per worker per minute instead of one per
+  request. Each Kong worker appends its JSON Lines records to
+  `karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl` (UTC minute) and rolls over
+  to a new file when the minute changes. This removes the per-request file (and
+  inode) churn of the old `<timestamp>-ka-auditlog-<request_id>.json` scheme and
+  is what log collectors expect: a few growing files to tail rather than a flood
+  of tiny ones. The record content is unchanged — `request_id` is still a field
+  in every entry, so logs stay searchable. **Breaking** for anything that
+  discovers audit files by the old filename pattern; the on-disk JSON is the
+  same.
+
 ## [1.2.1] - 2026-06-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ require "kong.plugins.karna.ka_seclang"
 The actual files live under `kong/plugins/karna/modules/` and `kong/plugins/karna/rules/`, but the rockspec maps short names (without `ka_` prefix in some cases — check the rockspec for the authoritative mapping).
 
 ## Audit Logging
-- Logs are written as JSON files to `auditlog_path` (default `/usr/local/openresty/nginx/logs`).
+- Logs are written to `auditlog_path` (default `/usr/local/openresty/nginx/logs`) as JSON Lines, one file per worker per minute: `karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl` (UTC minute). Each record is one appended line; the file rolls over implicitly when the minute changes (the computed filename changes — no rotation timer, no persistent handle, no lock). Per-worker isolation means no cross-process append. `request_id` stays in the record body, so logs are still searchable. Filename built in `ka_utils.lua:write_auditlog`; worker id + minute epoch passed from `handler.lua` log phase.
 - Format `v2` (default): one entry per request, all matched rules in `matches` array.
 - Format `v1` (legacy): last-match wins, ModSecurity-compatible when `auditlog_modsec` is enabled.
 - The upstream latency in v2 is read from header `x-karna-upstream-latency`

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ curl -X POST http://localhost:8001/services/<service_id>/plugins \
 | `rules_request` | array of stringified-JSON | n/a | Per-service local rules for the access / header_filter phase, including rule controls. |
 | `rules_response` | array of stringified-JSON | n/a | Per-service local rules for the response inspection. |
 | `auditlog_enabled` | bool | `true` | Write JSON audit logs. |
-| `auditlog_path` | string | `/usr/local/openresty/nginx/logs` | Audit log directory (must be writable by the Kong worker user). |
+| `auditlog_path` | string | `/usr/local/openresty/nginx/logs` | Audit log directory (must be writable by the Kong worker user). Karna writes JSON Lines, one file per worker per minute: `karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl` (UTC minute), rolled over when the minute changes. |
 | `auditlog_format` | string | `v2` | `v1` (legacy, ModSecurity-compatible when `auditlog_modsec=true`) or `v2` (per-request, all matches in `matches[]`). |
 | `auditlog_only_on_match` | bool | `false` | Only write audit log when at least one rule matched. |
 | `auditlog_modsec` | bool | `false` | v1 only, emit ModSecurity-compatible format. |

--- a/docs/configuration.html
+++ b/docs/configuration.html
@@ -269,12 +269,12 @@
 
     <section id="audit">
       <h2>Audit logging</h2>
-      <p>Karna writes JSON audit logs to disk asynchronously. The log directory must be writable by the Kong worker user.</p>
+      <p>Karna writes audit logs to disk asynchronously as JSON Lines, one file per worker per minute named <code>karna_auditlog_&lt;worker_id&gt;_&lt;YYYYMMDDHHMM&gt;.jsonl</code> (UTC minute), appending one record per line and rolling over when the minute changes. The log directory must be writable by the Kong worker user.</p>
       <table class="doc-table">
         <thead><tr><th>Option</th><th class="mono">Type · default</th><th>Description</th></tr></thead>
         <tbody>
           <tr><td class="name"><code>auditlog_enabled</code></td><td><span class="badge badge-type">boolean</span> <span class="badge badge-def">true</span></td><td>Write audit logs.</td></tr>
-          <tr><td class="name"><code>auditlog_path</code></td><td><span class="badge badge-type">string</span> <span class="badge badge-def">/usr/local/openresty/nginx/logs</span></td><td>Directory for the JSON log files. Must be <code>chown</code>ed to the Kong worker user.</td></tr>
+          <tr><td class="name"><code>auditlog_path</code></td><td><span class="badge badge-type">string</span> <span class="badge badge-def">/usr/local/openresty/nginx/logs</span></td><td>Directory for the <code>.jsonl</code> log files. Must be <code>chown</code>ed to the Kong worker user.</td></tr>
           <tr><td class="name"><code>auditlog_format</code></td><td><span class="badge badge-type">string</span> <span class="badge badge-def">v2</span></td><td>One of <code>v1</code> / <code>v2</code>. <code>v2</code> writes one entry per request with all matches in a <code>matches</code> array; <code>v1</code> is last-match-wins (ModSecurity-compatible when <code>auditlog_modsec</code> is on).</td></tr>
           <tr><td class="name"><code>auditlog_only_on_match</code></td><td><span class="badge badge-type">boolean</span> <span class="badge badge-def">false</span></td><td>Only write a log entry when at least one rule matched.</td></tr>
           <tr><td class="name"><code>auditlog_modsec</code></td><td><span class="badge badge-type">boolean</span> <span class="badge badge-def">false</span></td><td>Emit the ModSecurity-compatible audit format (with <code>v1</code>).</td></tr>

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1052,10 +1052,10 @@ function plugin:log(plugin_conf)
       ka_mcp.redact_audit(json_log, plugin_conf)
     end
 
-    -- write log to file
-    local timestamp = os.time(os.date("!*t"))
-    local request_id = ngx.var.request_id
-    ngx.timer.at(0, utils.write_auditlog, json_log, plugin_conf.auditlog_path, timestamp, request_id)
+    -- write log to file (one JSONL file per worker per minute; see write_auditlog)
+    local now = ngx.time()
+    local worker_id = ngx.worker.id() or 0
+    ngx.timer.at(0, utils.write_auditlog, json_log, plugin_conf.auditlog_path, now, worker_id)
   end
 end
 

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -644,15 +644,21 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
     return json_log
 end
 
-_M.write_auditlog = function(premature, json_log, auditlog_path, timestamp, request_id)
+_M.write_auditlog = function(premature, json_log, auditlog_path, timestamp, worker_id)
     if premature then return end
 
     local cjson = require "cjson"
 
-    -- write a file log
-    local filename = auditlog_path.."/"..timestamp.."-ka-auditlog-"..request_id..".json"
+    -- One file per worker per minute, appended as JSON Lines. The filename
+    -- carries the UTC minute, so rotation is implicit: when the minute rolls
+    -- over the computed name changes and writes land in a fresh file. Each
+    -- Kong worker is a separate process and owns its file via <worker_id>, so
+    -- there is no cross-process append to the same file and no lock is needed.
+    local minute = os.date("!%Y%m%d%H%M", timestamp)
+    local wid = worker_id or 0
+    local filename = auditlog_path.."/karna_auditlog_"..wid.."_"..minute..".jsonl"
     kong.log.debug("Karna: writing audit log to file: ", filename)
-    local file = io.open(filename, "w")
+    local file = io.open(filename, "a")
     if file then
         -- Strip any embedded CR/LF so the record is a single physical line,
         -- then terminate it with one trailing newline. This is the JSON Lines


### PR DESCRIPTION
## What

Replace the one-file-per-request audit log scheme (`<timestamp>-ka-auditlog-<request_id>.json`) with **one file per worker per minute**:

```
karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl   (UTC minute)
```

Each Kong worker appends its JSON Lines records to its current-minute file and rolls over when the minute changes.

## Why

- Removes the per-request file (and inode) churn of the old scheme.
- Matches what log collectors (Filebeat, Fluent Bit, Vector, Promtail) expect: a few growing files to tail, not a flood of tiny ones — the natural fit for the JSON Lines format already adopted.

## How

- **Rotation is implicit**: the filename is derived from the current UTC minute at write time. When the minute changes, the computed name changes and writes land in a fresh file. No rotation timer, no persistent handle, no lock.
- **Concurrency**: each worker is a separate process and owns its file via `<worker_id>` → no cross-process append. Within a worker, timer callbacks run cooperatively and the blocking `io.open/write/close` calls never yield, so appends serialise on their own.
- `handler.lua` passes a correct epoch (`ngx.time()`, dropping the buggy `os.time(os.date("!*t"))` round-trip) plus the worker id to `write_auditlog`.

## Compatibility

**Breaking** for anything that discovers audit files by the old filename pattern. The on-disk JSON is unchanged — `request_id` is still a field in every record, so logs stay searchable.

## Verification

- CRS PL1 regression (dev stack): **2757/2757 (100%)**, empty-diff — the change does not touch the detection path.
- End-to-end on the dev stack: per-worker files, real rollover across a minute boundary (`…0744.jsonl` → `…0745.jsonl`), multiple records appended per file, blocked attack (403) logged, every line valid JSON with a trailing newline.
- Isolated unit checks of `write_auditlog` (filename / append mode / newline / nil-worker / premature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)