### PR TITLE
feat(engine): resolve response.* variables in rule conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Rule conditions can now match on `response.*` variables — `response.status`,
+  `response.header.value[:name]`, `response.header.name[:name]`, and
+  `response.set_cookie.*` — in the `header_filter` phase. These were already
+  populated for `%{...}` macro substitution (audit-log fields, Redis keys) but
+  had no branch in the condition matcher, so a condition on `response.status`
+  silently never matched. A response-phase rule can now key on a response
+  signal — for example a failed login, which returns a distinct status — and
+  drive a side effect such as a `redis_incr_key` counter, with an access-phase
+  rule reading that counter to rate-limit or ban the source. Access-phase rules
+  run before the response exists, so `response.*` resolves to nothing there.
+
 ### Changed
 
 - Audit log files are now written one per worker per minute instead of one per
@@ -19,6 +32,17 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   in every entry, so logs stay searchable. **Breaking** for anything that
   discovers audit files by the old filename pattern; the on-disk JSON is the
   same.
+
+### Fixed
+
+- `__get_value_from_inspection_table` no longer crashes when the inspection
+  table holds a bare-string entry. A Set-Cookie value can flatten to a plain
+  string rather than a `{key=value}` table (the same shape the 1.2.1
+  response-cookie fix handled on the population side); the reader assumed every
+  entry was a table and called `pairs()` on it. It now skips non-table entries.
+  The crash was latent — reachable by any `%{...}` macro resolved in
+  `header_filter` after a cookie-setting response — and was surfaced by the new
+  `response.*` condition resolver, which reads the same table during matching.
 
 ## [1.2.1] - 2026-06-26
 

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -2545,6 +2545,38 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                     values, err = self.__get_values_request_cookie(false)
                 end
 
+                -- response.* — resolve response signals in conditions
+                -- (response.status / response.header.value[:name] /
+                -- response.header.name[:name] / response.set_cookie.*).
+                -- get_inspection_table() flattens these into the
+                -- inspection_table during header_filter (see :4462+), so
+                -- read them back from there. Three shapes, mirroring the
+                -- request.* selectors: the exact key (response.status), a
+                -- :<name> selector (response.header.value:host), and the
+                -- collection form (response.header.value → every :<name>
+                -- key under it). Access-phase rules run before the response
+                -- exists, so the inspection_table holds no response.* key
+                -- then and this resolves to nothing (a silent no-match) —
+                -- response conditions only bite in header_filter.
+                if string_find(variable, "^response%.") then
+                    local pat
+                    if string_find(variable, ":", 1, true) then
+                        pat = "^" .. variable:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1") .. "$"
+                    elseif variable == "response.status" then
+                        pat = "^response%.status$"
+                    else
+                        pat = "^" .. variable:gsub("([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1") .. ":"
+                    end
+                    local rows = self:__get_value_from_inspection_table(pat)
+                    if rows and #rows > 0 then
+                        values = {}
+                        for _, row in pairs(rows) do
+                            for k, v in pairs(row) do values[k] = v end
+                        end
+                        if next(values) == nil then values = nil end
+                    end
+                end
+
                 -- request.body.multipart.name / .filename (no selector)
                 -- → ModSec FILES_NAMES / (alongside FILES). Collect every
                 -- multipart part's `name=` (or `filename=`) so the
@@ -4552,10 +4584,18 @@ _M.__get_value_from_inspection_table = function(self, pattern, filter_out_patter
         return return_table
     end
     for _,v in pairs(kong.ctx.plugin.inspection_table) do
-        for key,_ in pairs(v) do
-            if string_match(key, pattern) then
-                if not string_match(key, filter_out_pattern) then
-                    table_insert(return_table, v)
+        -- Entries are normally single-key {key=value} tables, but the
+        -- Set-Cookie flattening (get_inspection_table :4543) can push a
+        -- bare string value with no key. Those carry nothing to match a
+        -- named pattern against, so skip them — pairs() on a string here
+        -- would crash header_filter for any caller (macro resolution or
+        -- the response.* condition resolver).
+        if type(v) == "table" then
+            for key,_ in pairs(v) do
+                if string_match(key, pattern) then
+                    if not string_match(key, filter_out_pattern) then
+                        table_insert(return_table, v)
+                    end
                 end
             end
         end


### PR DESCRIPTION
## What

The rule-condition matcher (`__match_rule_conditions_impl`) resolved `request.*`, `redis.*`, `tx.*`, `geoip.*`, `mcp.*` etc. but had **no branch for `response.*`**. Those variables (`response.status`, `response.header.*`, `response.set_cookie.*`) were only populated into the `inspection_table` for `%{...}` macro substitution, so a condition like `response.status eq 200` in a `header_filter` rule silently never matched (no WARN — just a debug line).

This made the shipped "failed-auth rate-limit / ban" recipe (recipes.md) **non-functional**: its response-phase counting rule could never fire, so the counter never incremented and the ban never triggered.

## Changes

- **Add a `response.*` branch** to the condition matcher that reads the already-populated `inspection_table` (status / headers / Set-Cookie), supporting the exact key (`response.status`), a `:<name>` selector (`response.header.value:host`), and the collection form (`response.header.value`), mirroring the `request.*` selectors. Access-phase rules run before the response exists, so `response.*` resolves to nothing there; the `^response%.` prefix check is a cheap early-out on the hot path.
- **Harden `__get_value_from_inspection_table`** to skip non-table entries. Set-Cookie values can flatten to a bare string (the same shape the [1.2.1] fix handled on the *population* side); the reader called `pairs()` on every entry and crashed `header_filter`. Latent for any `%{...}` macro resolved after a cookie-setting response; the new resolver surfaced it. Sibling fix to 1.2.1.

## Verification

- **Live** (WordPress behind Karna): 6 failed logins → HTTP 200, Redis counter 1→6; 7th → **429** (banned); a successful login → 302 and **not counted**. No runtime errors.
- **CRS PL1 regression: 2757/2757 (100%), empty diff** — `response.*` isn't used by in-scope CRS rules, and the hardening only skips keyless entries.

## Notes

Makes the existing recipe (merged in #19) and the `response.*` rows in rules.md correct — no doc change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)