### PR TITLE
refactor(engine): remove dead rules_response field; cache header_filter subset

### DIFF
--- a/.claude/skills/karna/reference/configuration.md
+++ b/.claude/skills/karna/reference/configuration.md
@@ -6,7 +6,7 @@ under the plugin `config` block. Defaults shown in `(parens)`.
 ## Engine & blocking
 - `engine_blocking_mode` (bool, `false`) — block on match (default 403) vs detection-only. Start `false`.
 - `coreruleset_enabled` (bool, `true`) — load/evaluate the OWASP CRS pack. The in-repo CRS-fix controls always apply regardless.
-- `local_rules_enabled` (bool, `true`) — evaluate `rules_request` / `rules_response`.
+- `local_rules_enabled` (bool, `true`) — evaluate the custom rules in `rules_request`.
 - `set_karna_headers` (bool, `false`) — add diagnostic response headers.
 
 ## CRS category toggles (under `coreruleset_rulesets`, gated by `coreruleset_enabled`)
@@ -51,8 +51,7 @@ To loosen a gate, raise its value / extend its allow-list. They cannot be turned
 - `crs_plugins_enabled` (array, `[]`) — plugin dir names to load (e.g. `wordpress-rule-exclusions-plugin`).
 
 ## Custom rules
-- `rules_request` (array) — per-service request rules (JSON strings). See `rules.md`.
-- `rules_response` (array) — per-service response rules.
+- `rules_request` (array) — per-service custom rules (JSON strings), all phases. Each rule runs in the phase named by its `phase` field (`access` or `header_filter`); response-phase rules use `"phase": "header_filter"`. See `rules.md`.
 - `custom_secrules` (array, `[]`) — inline SecLang `SecRule` strings.
 
 ## Action / response overrides (change existing rules without editing the pack)

--- a/.claude/skills/karna/reference/recipes.md
+++ b/.claude/skills/karna/reference/recipes.md
@@ -1,8 +1,10 @@
 # Karna recipes
 
 Concrete tasks. Each assumes Karna is already attached to a service (see
-`deploy.md`). Add rules as JSON strings to the plugin's `rules_request` /
-`rules_response` arrays, or use config-level overrides for the CRS pack.
+`deploy.md`). Add rules as JSON strings to the plugin's `rules_request` array —
+every custom rule goes there regardless of phase; the engine runs each in the
+phase named by its `phase` field (`access` or `header_filter`). Config-level
+overrides tune the CRS pack.
 
 ## Turn on blocking (after tuning)
 Only after the audit log is clean in detection-only:

--- a/.claude/skills/karna/reference/rules.md
+++ b/.claude/skills/karna/reference/rules.md
@@ -1,8 +1,10 @@
 # Karna rule reference
 
-A rule is a JSON object placed in `rules_request` (request phase) or
-`rules_response` (response phase). It fires when **all** conditions match, then runs
-its `action`. Authoritative engine: `kong/plugins/karna/modules/ka_engine.lua`.
+A rule is a JSON object placed in the `rules_request` array — every custom rule
+goes there regardless of phase, and the engine runs it in the phase named by its
+`phase` field. There is no separate response array; the engine dispatches by
+phase. A rule fires when **all** its conditions match, then runs its `action`.
+Authoritative engine: `kong/plugins/karna/modules/ka_engine.lua`.
 
 ## Rule shape
 
@@ -27,10 +29,20 @@ Condition fields: `variables[]`, `op`, `value`, `transform[]` (omit/`[]` for non
 Conditions are AND-ed (a chain). Later conditions can read `matched.value` and capture groups `group:0`, `group:1`, …
 
 ## Phases
+Set a rule's `phase` to one of these. Custom rules run in `access` and
+`header_filter` only.
 - `access` — before upstream. Inspects method/path/query/headers/cookies/parsed body. Can block, sanitize, modify. Most rules.
-- `header_filter` — after upstream responds. Request + response status/headers.
-- `body_filter` — response body streaming (internal MCP SSE reassembly).
-- `mcp_event` — per reassembled SSE event (Karna-native); can drop/replace/terminate/inject events.
+- `header_filter` — after upstream responds. Sees the request plus `response.status` / `response.header.*` / `response.set_cookie.*` (resolvable in conditions, not just in `%{}` macros). Use this to react to the response — e.g. count a failed login by its status.
+- `body_filter` — response body. Custom rules in this phase are **not currently evaluated** (the handler dispatch is commented out); the phase is used internally for MCP SSE reassembly.
+- `mcp_event` — per reassembled SSE event (Karna-native, MCP only); can drop/replace/terminate/inject events.
+
+## Evaluation order
+Within a phase the engine runs the rules in order. Non-terminal side effects
+(`set_variable`, `set_log_fields`, `redis_incr_key`) fire on **every** matching
+rule. The first rule whose action is **terminal** (`fixed_response`,
+`fix_matched_parts`, `rate_limit`) stops evaluation and wins. So a counter that
+must always increment belongs on a non-terminal rule, and a "block if already
+banned" check placed first short-circuits the rest.
 
 ## Variables (append `:<selector>` to target a named element)
 - `request.arg.value` / `.name` — query + parsed body args (canonical "any arg"). Target one: `request.arg.value:<name>`.
@@ -41,7 +53,7 @@ Conditions are AND-ed (a chain). Later conditions can read `matched.value` and c
 - `request.raw_path`, `request.basename`, `request.method`.
 - `request.file`, `request.body.multipart.filename`, `request.body.multipart.header.value`.
 - `request.header.referer.{path,query,scheme,host}`.
-- `response.set_cookie.value` / `.name`, `response.header.name:<name>` (response phases).
+- `response.status`, `response.header.value:<name>` / `.name:<name>`, `response.set_cookie.value` / `.name` (header_filter phase; resolvable in conditions).
 - `matched.value`, `group:<n>` (chain refs).
 - `tx:<name>` / `var:<name>` (CRS TX vars, e.g. `var:paranoia_level`).
 - `redis.<key>` — inspect a Redis key (read-only). Everything after `redis.` is the key name (macros allowed: `%{remote_addr}`, `%{request.method|host|scheme|path}`, `%{request_headers.X}`). The **operator picks the command**: `isSet`→EXISTS (ban/existence check; `negated:true`→absent), `eq`/`rx`/`contains`/`beginsWith`→GET+compare, `gt`/`lt`/`ge`/`le`→GET+numeric, `redis_sismember`→SISMEMBER, `redis_hexists`→HEXISTS. Needs `redis_inspect_enabled`. (Legacy `redis.key:<macro>` GET form is dead — use `redis.<key>`.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   discovers audit files by the old filename pattern; the on-disk JSON is the
   same.
 
+### Removed
+
+- The `rules_response` config field. It was declared in the schema but consumed
+  nowhere — a rule placed there never ran, silently. All custom rules go in
+  `rules_request` and run in the phase named by each rule's `phase` field
+  (`access` or `header_filter`); the header_filter subset is now precomputed and
+  cached, so a response pass iterates only response-phase rules — which is what
+  the separate array was meant to achieve. **Breaking** only if a deployment
+  declared `rules_response`: Kong rejects an unknown config field on reload, so
+  drop the entry. It was a no-op, so nothing of substance is lost.
+
 ### Fixed
 
 - `__get_value_from_inspection_table` no longer crashes when the inspection

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ plugin with no required dependency on other plugins.
   - `paranoia_level` (number, 1-4): OWASP CRS paranoia level.
   - `coreruleset_enabled` (default true): toggle for the OWASP CRS rule pack loaded from disk at `init_worker`. The in-repo CRS-fix rule controls (`coreruleset_fix.lua`) are always applied independently.
   - `local_rules_enabled`: per-service custom rules.
-  - `rules_request` / `rules_response`: per-service JSON rule arrays.
+  - `rules_request`: per-service JSON rule array (all phases; each rule runs in the phase named by its `phase` field — `access` or `header_filter`).
   - `auditlog_enabled`, `auditlog_path`, `auditlog_modsec`: audit logging config.
   - `redis_host`, `redis_port`, `redis_password`: Redis connection for counters.
   - Various request validation limits (arg length, arg count, methods, content types, extensions, charsets).

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Karna inspects every request against a layered rule pipeline:
    adjust, exclude, or rewrite global rules at request time. Includes the
    in-repo CRS-fix layer (`coreruleset_fix.lua`) that neutralises known
    false-positive-prone OWASP CRS rules in production deployments.
-3. **Per-service local rules** (`rules_request`, `rules_response`): your
-   own custom rules. Gated by `local_rules_enabled` (default `true`).
+3. **Per-service local rules** (`rules_request`): your own custom rules,
+   each run in the phase named by its `phase` field (access or
+   header_filter). Gated by `local_rules_enabled` (default `true`).
 4. **OWASP CoreRuleSet** loaded from disk at `init_worker`. Gated by
    `coreruleset_enabled` (default `true`).
 
@@ -634,7 +635,7 @@ curl -X POST http://localhost:8001/services/<service_id>/plugins \
 |---|---|---|---|
 | `engine_blocking_mode` | bool | `false` | If `true`, matched rules return their `fixed_response` action (typically 403). If `false`, matches are logged only. |
 | `coreruleset_enabled` | bool | `true` | Toggle for the OWASP CRS rule pack loaded from disk at `init_worker`. The in-repo CRS-fix rule controls (`coreruleset_fix.lua`) are always applied. |
-| `local_rules_enabled` | bool | `true` | Toggle for `rules_request` / `rules_response` local rules. |
+| `local_rules_enabled` | bool | `true` | Toggle for `rules_request` local rules. |
 | `ignore_from_local_ips` | bool | `true` | Skip WAF for clients in `127.0.0.0/8`, `192.168.0.0/16`, `10.0.0.0/8`, `172.16.0.0/12`, `::1`, `fe80::/32`. |
 | `paranoia_level` | number | `1` | OWASP CRS paranoia level (1-4). Rules whose declared paranoia level exceeds this value are skipped at evaluation time. Rules without an explicit PL tag (Karna-native gates, `coreruleset_fix.global_fps`, user-supplied local rules) default to PL1 and always run when this setting is ≥ 1. |
 | `set_karna_headers` | bool | `false` | Set `X-Karna-Engine` / `X-Karna-Engine-Version` response headers. |
@@ -655,8 +656,7 @@ curl -X POST http://localhost:8001/services/<service_id>/plugins \
 | `crs_plugins_path` | string | `/opt/coreruleset-plugins/` | Directory holding the CRS plugins you downloaded. See [CRS plugins](#crs-plugins-wordpress-drupal-etc). |
 | `crs_plugins_enabled` | array | `[]` | Plugin directory names to load, e.g. `["wordpress-rule-exclusions-plugin"]`. |
 | `custom_secrules` | array | `[]` | SecLang rule strings parsed at load. Use it for inline exclusions without a plugin directory. |
-| `rules_request` | array of stringified-JSON | n/a | Per-service local rules for the access / header_filter phase, including rule controls. |
-| `rules_response` | array of stringified-JSON | n/a | Per-service local rules for the response inspection. |
+| `rules_request` | array of stringified-JSON | n/a | Per-service local rules for all phases, including rule controls. Each rule runs in the phase named by its `phase` field (`access` or `header_filter`). |
 | `auditlog_enabled` | bool | `true` | Write JSON audit logs. |
 | `auditlog_path` | string | `/usr/local/openresty/nginx/logs` | Audit log directory (must be writable by the Kong worker user). Karna writes JSON Lines, one file per worker per minute: `karna_auditlog_<worker_id>_<YYYYMMDDHHMM>.jsonl` (UTC minute), rolled over when the minute changes. |
 | `auditlog_format` | string | `v2` | `v1` (legacy, ModSecurity-compatible when `auditlog_modsec=true`) or `v2` (per-request, all matches in `matches[]`). |

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -93,15 +93,21 @@ end
 -- API update, which invalidates the cache automatically. Previously
 -- cjson.decode ran twice per rule per request (pcall validate + actual
 -- decode); now it runs once per (worker, plugin_conf) lifetime.
--- The returned table carries two views:
---   .all    : every parsed rule, used as the cross-phase
---             kong.ctx.plugin.local_rules (header_filter / body_filter
---             / mcp_event filter by .phase).
---   .access : the subset whose .phase == "access", consumed directly
---             by the access-phase rule loop.
+-- The returned table carries these views:
+--   .all           : every parsed rule, used as the cross-phase
+--                    kong.ctx.plugin.local_rules (body_filter / mcp_event
+--                    filter by .phase).
+--   .access        : the subset whose .phase == "access", consumed
+--                    directly by the access-phase rule loop.
+--   .header_filter : the subset whose .phase == "header_filter", consumed
+--                    directly by the header_filter loop. Precomputing it
+--                    means a response pass iterates only response-phase
+--                    rules, not the whole set filtered per request — this
+--                    is why there is no separate `rules_response` config
+--                    array; the phase field plus this cache do the job.
 local get_local_request_rules = function(plugin_conf)
   if not plugin_conf.rules_request or #plugin_conf.rules_request == 0 then
-    return { all = {}, access = {} }
+    return { all = {}, access = {}, header_filter = {} }
   end
   local key = "local_request_rules:" .. tostring(plugin_conf)
   local cached = ka_rules:get(key)
@@ -109,12 +115,15 @@ local get_local_request_rules = function(plugin_conf)
 
   local all = {}
   local access = {}
+  local header_filter = {}
   for _, req_rule_raw in pairs(plugin_conf.rules_request) do
     local ok, req_rule_or_err = pcall(cjson.decode, req_rule_raw)
     if ok then
       table.insert(all, req_rule_or_err)
       if req_rule_or_err.phase == "access" then
         table.insert(access, req_rule_or_err)
+      elseif req_rule_or_err.phase == "header_filter" then
+        table.insert(header_filter, req_rule_or_err)
       end
     else
       kong.log.err("Error parsing JSON rule: " .. tostring(req_rule_or_err))
@@ -123,7 +132,7 @@ local get_local_request_rules = function(plugin_conf)
 
   ka_compile.compile_rules(all, plugin_conf)
 
-  local result = { all = all, access = access }
+  local result = { all = all, access = access, header_filter = header_filter }
   ka_rules:set(key, result)
   return result
 end
@@ -917,19 +926,13 @@ function plugin:header_filter(plugin_conf)
     debug("Loaded "..tostring(#rules).." global rules")
   end
 
-  -- get service local request rules
-  local local_rules_request = {}
-  if kong.ctx.plugin.local_rules then
-    for _,req_rule in pairs(kong.ctx.plugin.local_rules) do
-      if req_rule.phase == "header_filter" then
-        table.insert(local_rules_request, req_rule)
-      end
-    end
-  end
-
-  -- local rules
+  -- Header_filter-phase local rules. Use the precomputed, cached
+  -- header_filter subset (get_local_request_rules is LRU-cached per
+  -- plugin_conf) so the response pass iterates only response-phase rules
+  -- instead of filtering the whole set on every request.
   if plugin_conf.local_rules_enabled then
-    evaluate_rules(plugin_conf, local_rules_request, "header_filter")
+    local header_filter_rules = get_local_request_rules(plugin_conf).header_filter
+    evaluate_rules(plugin_conf, header_filter_rules, "header_filter")
   end
 end
 

--- a/kong/plugins/karna/schema.lua
+++ b/kong/plugins/karna/schema.lua
@@ -186,8 +186,13 @@ local schema = {
           -- remain available for the same purpose; the two coexist.
           { custom_secrules = { type = "array", elements = { type = "string" }, default = {} } },
 
+          -- All custom rules live here regardless of phase; the engine
+          -- runs each in the phase named by its `phase` field (access /
+          -- header_filter). There is deliberately no separate response
+          -- array — the per-phase subset is precomputed and cached in
+          -- handler.lua:get_local_request_rules, so a response-phase pass
+          -- iterates only the response-phase rules, not the whole set.
           { rules_request = { type = "array", elements = { type = "string" } } },
-          { rules_response = { type = "array", elements = { type = "string" } } },
 
           -- Per-rule action and response overrides — Karna's escape
           -- hatch for the "I trust this WAF, but for rule X I want to


### PR DESCRIPTION
## What

`rules_response` was declared in `schema.lua` but consumed **nowhere** — a rule placed there never ran, silently. The skill (recipes.md, rules.md, configuration.md) and README/CLAUDE.md listed it as a valid target, so an operator could author a response-phase rule that looks right and never fires.

## Changes

- **Remove `rules_response`** from the schema. Every custom rule goes in `rules_request` and runs in the phase named by its `phase` field (`access` / `header_filter`).
- **Cache the `header_filter` subset** in `get_local_request_rules` (next to `.access`) and consume it directly in the `header_filter` handler. This is the perf intent the separate array was meant to serve — a response pass iterates only response-phase rules instead of filtering the whole set on every request — achieved via the phase field + cache. Drops the per-request phase-filter loop in `header_filter`.
- **Docs** (recipes.md, rules.md, configuration.md, README.md, CLAUDE.md): describe the single `rules_request` array + phase dispatch, the live phases (`access`, `header_filter`), evaluation order (non-terminal side effects fire on every match; the first terminal action wins), the now-resolvable `response.*` condition variables, and note that `body_filter` local rules are not currently evaluated.

## Verification

- **CRS PL1 regression: 2757/2757 (100%), empty diff.**
- **Live** (WordPress behind Karna): the failed-login counter increments via the cached `header_filter` subset (redis 1→6); 6 fails → 200, 7th → 429.

## Breaking

Only for a config that declared `rules_response` (a no-op field): Kong rejects an unknown config field on reload, so drop the entry. Nothing of substance is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)