### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-06
+
 ### Added
 
 - Rule conditions can now match on `response.*` variables — `response.status`,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.2.1-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.3.0-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.2.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.3.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.2.1-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.2.1-0.rockspec:ro
+      - ../kong-plugin-karna-1.3.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.3.0-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
 
     command: >

--- a/kong-plugin-karna-1.3.0-0.rockspec
+++ b/kong-plugin-karna-1.3.0-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.2.1-0"
+version = "1.3.0-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.2.1"
+  tag = "v1.3.0"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.2.1",
+  VERSION = "1.3.0",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.2.1",
+  version      = "1.3.0",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.2.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.3.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
Cut **v1.3.0**. Bundles the [Unreleased] work into a release and syncs the version across `version.lua`, `handler.lua`, the rockspec (renamed to `kong-plugin-karna-1.3.0-0.rockspec`), the Dockerfile stamp and `install.sh`.

## Highlights
- **Added** — `response.*` variables (`response.status` / header / set-cookie) resolve in rule conditions (`header_filter`), enabling failed-login / response-signal rate-limit and auto-ban recipes.
- **Removed** — the dead `rules_response` config field; all rules live in `rules_request` and dispatch by phase, with the `header_filter` subset cached.
- **Fixed** — `__get_value_from_inspection_table` crash on bare-string Set-Cookie entries.
- **Changed** — audit logs written one file per worker per minute.

## Breaking
- Configs that declared `rules_response` (a no-op field) must drop it.
- Anything discovering audit files by the old `<timestamp>-ka-auditlog-<request_id>.json` pattern.

See CHANGELOG.md for the full [1.3.0] entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)