### PR TITLE
docs(skill): route rule work to recipes+rules; no Lua needed for rules

### DIFF
--- a/.claude/skills/karna/SKILL.md
+++ b/.claude/skills/karna/SKILL.md
@@ -13,18 +13,28 @@ Karna, **configuring** it, and **writing rules**.
 
 ## How to use this skill
 
-Read the reference file for the job at hand. Do not load all of them up front.
+Read the reference file for the job at hand — but for anything involving rules,
+read **both** `reference/recipes.md` and `reference/rules.md`. Recipes gives the
+worked pattern; rules gives the shared mechanics (phases, evaluation order,
+variables, operators, actions) that every recipe relies on. A task that looks
+like a single recipe often needs the mechanics too — e.g. combining several rules
+in one phase depends on the evaluation order documented in `rules.md`. Don't load
+files unrelated to the task.
 
 | Job | Read |
 |-----|------|
 | Install / deploy (Docker or existing Kong), attach to a service | `reference/deploy.md` |
 | Set or explain a plugin config option | `reference/configuration.md` |
-| Write a rule: variables, operators, transforms, actions, controls | `reference/rules.md` |
-| Do a concrete task (block X, sanitize Y, rate-limit Z, fix an FP) | `reference/recipes.md` |
+| Write, compose, combine, or order rules (detection / sanitize / rate-limit / ban / FP) | `reference/recipes.md` **and** `reference/rules.md` |
 
-The authoritative source for config is `kong/plugins/karna/schema.lua`; for the
-rule engine it is `kong/plugins/karna/modules/ka_engine.lua`. When in doubt, read
-the code, not your memory.
+**You do not need to read the Lua source to author rules.** Everything required
+to write, combine, and order rules — variables, operators, transforms, actions,
+phases, and evaluation order — is in `recipes.md` and `rules.md`. Treat those two
+as authoritative for rule work. The engine source
+(`kong/plugins/karna/modules/ka_engine.lua`) and schema
+(`kong/plugins/karna/schema.lua`) are the ultimate source of truth and worth
+reading only to confirm a deep engine internal the reference genuinely does not
+cover — not for normal rule authoring.
 
 ## Golden rules (do not skip)
 

--- a/.claude/skills/karna/reference/recipes.md
+++ b/.claude/skills/karna/reference/recipes.md
@@ -6,6 +6,15 @@ every custom rule goes there regardless of phase; the engine runs each in the
 phase named by its `phase` field (`access` or `header_filter`). Config-level
 overrides tune the CRS pack.
 
+Combining several rules in one phase? Order matters, and you don't need to read
+the engine to know how: within a phase the engine runs the rules in array order,
+the first rule with a *terminal* action (`fixed_response` / `fix_matched_parts` /
+`rate_limit`) wins and stops the phase, while *non-terminal* actions
+(`redis_incr_key` / `set_variable` / `redis_set`) apply their effect and let
+evaluation continue. So put the most general terminal check (e.g. "block if
+already banned") first, and keep counters/side-effects on non-terminal rules.
+Full detail in `rules.md` → "Evaluation order".
+
 ## Turn on blocking (after tuning)
 Only after the audit log is clean in detection-only:
 ```sh
@@ -107,6 +116,15 @@ swap the counting rule's conditions for:
 For a ban that outlives the counter window, replace the block action with
 `redis_set` (`{ "key": "ban:%{remote_addr}", "expire": 3600 }`) on the threshold
 and reuse the `block-banned` rule above.
+
+Rule order when you combine these (all in `rules_request`, access phase runs in
+array order): put **`block-banned` first** — it's the most general terminal check,
+so once an IP is banned it short-circuits the rest and never touches the backend
+— then `authfail-block` (the threshold check), then any broad `rate_limit` rule
+last. A `rate_limit` on `/login` is terminal and matches every login request, so
+if you place it first it stops the phase and the ban rules never run. The
+`authfail-count` rule is `header_filter` phase, so it lives in the response pass
+and doesn't compete for order with the access rules.
 
 ## Reject a revoked credential from a shared set
 Needs `redis_inspect_enabled=true`. A sibling plugin (or your auth service) keeps a


### PR DESCRIPTION
## Why

Repeated agent tests read `ka_engine.lua` while authoring rules. Root cause this round is **routing**, not missing info: an agent doing a "concrete task" loaded only `recipes.md` and — per SKILL.md's "don't load all files up front" — never opened `rules.md`, where the rule **evaluation order** is already documented. So it went to the engine source to learn what the reference already said.

## Changes

- **SKILL.md** — for any rule work, read **both** `recipes.md` and `rules.md`; merge the two rule rows in the routing table; and state plainly: **authoring rules needs no Lua reading** — the two reference files are authoritative; the engine/schema source is only for confirming deep internals the reference doesn't cover.
- **recipes.md** — inline the multi-rule ordering fact (first *terminal* action wins and stops the phase; *non-terminal* side effects fire and continue) in the intro, so it's present at the point of composition rather than one file away; and spell out the recommended order (block-banned first, `rate_limit` last) in the failed-login ban recipe.

Docs-only. The published skill tarball (`karna.sicuranext.com/skill/karna-skill.tar.gz`, currently dated 2026-06-07) will be repackaged and re-uploaded so installed agents actually get this and the other skill fixes from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)