### PR TITLE
fix(multipart): scope strict-CRLF bare-CR check to framing (unblock binary uploads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-07-20
+
 ### Fixed
 
 - Multipart body parser no longer rejects binary file uploads that carry a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Multipart body parser no longer rejects binary file uploads that carry a
+  bare CR (a `0x0D` byte not followed by `0x0A`). Such bytes are ordinary data
+  inside opaque part content — a ~1 MB image contains thousands of them — but
+  the old body-wide bare-CR scan treated any of them as a framing desync and
+  blocked the request with `request_body_parser_violation`. In practice that
+  rejected essentially every real file upload (for example an image POST to
+  Ghost's admin upload endpoint). Strict-CRLF enforcement is now scoped to the
+  multipart framing (boundary lines, part headers, the header/body separator),
+  the same way bare LF was already handled; inside a part body a bare CR or LF
+  is kept verbatim. A bare CR embedded in framing is still rejected, and CRS
+  regression is unchanged (2757/2757).
+- Closed a related evasion and O(n²) cost in the same parser. The line splitter
+  used to drop the bytes between a bare CR and the next LF, which let a payload
+  hidden in a non-file field value skip ARGS inspection; it now splits on `\n`
+  only so those bytes survive and are scanned. Part-body reconstruction also
+  buffers lines and joins once instead of concatenating per line, so a large
+  upload (or a body padded with newlines) no longer costs seconds of worker CPU.
+
 ## [1.4.0] - 2026-07-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,9 +140,22 @@ pass-rate floor.
 
 ## Versioning
 SemVer + LuaRocks revision (`MAJOR.MINOR.PATCH-REV`). **Don't forget**: on every
-release keep three things in sync — `version` in `kong/plugins/karna/version.lua`
-(the source of truth; `handler.lua` sets `plugin.VERSION = ka_version.version`),
-the rockspec `version` (carries the `-REV` suffix), and the rockspec filename.
+release the version string is duplicated across six spots that must all move
+together (a bare `grep -rn "<old-version>"` before pushing catches strays — the
+rockspec rename in particular breaks a hardcoded `COPY` in the Dockerfile and CI
+fails at image build, not at the test):
+1. `version` in `kong/plugins/karna/version.lua` — the source of truth;
+   `handler.lua` sets `plugin.VERSION = ka_version.version` at load. (`handler.lua`
+   also carries a static `VERSION = "<ver>"` placeholder that is overwritten at
+   load — cosmetic, but bump it too so the grep stays clean.)
+2. the rockspec `version` field (carries the `-REV` suffix).
+3. the rockspec `source.tag` (`v<MAJOR.MINOR.PATCH>`).
+4. the rockspec **filename** (`kong-plugin-karna-<ver>-<rev>.rockspec`).
+5. `docker/Dockerfile` — the `COPY kong-plugin-karna-<ver>-<rev>.rockspec` line
+   AND the `version = "<ver>"` string in the build-time `version.lua` stamp.
+6. `docker/docker-compose.dev.yml` — the rockspec bind-mount path (both sides),
+   and `scripts/install.sh` — the `version = "<ver>"` string in its stamp.
+
 `version.lua` is committed with placeholder `commit`/`built_at`; the build stamps
 the real commit (Docker build arg `KARNA_COMMIT`, or `scripts/install.sh` via
 `git rev-parse`). `scripts/build.sh` wraps the stamped Docker build.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -95,11 +95,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.4.0-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.4.1-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.4.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.4.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -122,7 +122,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.4.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.4.0-0.rockspec:ro
+      - ../kong-plugin-karna-1.4.1-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.4.1-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
 
     command: >

--- a/ka-unittest/multipart_security_gaps.lua
+++ b/ka-unittest/multipart_security_gaps.lua
@@ -238,6 +238,71 @@ do
 end
 
 -- ===========================================================================
+print("== Gap #4b: bare CR scoped to framing (binary-upload false positive) ==")
+-- ===========================================================================
+-- A bare CR (0x0D not followed by 0x0A) is ordinary data inside a part body:
+-- binary uploads (images/PDFs) carry thousands of them. The old body-wide
+-- bare-CR scan rejected every such upload ("bare CR found in body"). It's now
+-- enforced only on FRAMING; inside part content a bare CR is kept verbatim.
+
+do
+    -- The Ghost image-upload FP: a file part whose bytes contain a bare CR.
+    local body = build_body({
+        { cd_header = 'Content-Disposition: form-data; name="file"; filename="pic.png"',
+          content_type = "image/png",
+          body = "PNG\r\137DATA\rMORE" },  -- raw 0x0D bytes, not CRLF
+    })
+    local r, err = mp:parse(body, CT)
+    check("binary file with bare CR → accepted (no 'bare CR' block)",
+          r and r[1] and not (err and err:find("bare CR")),
+          "got: " .. tostring(err))
+    check("binary file body preserved byte-for-byte (CR kept, none dropped)",
+          r and r[1] and r[1].body == "PNG\r\137DATA\rMORE",
+          "got body=" .. tostring(r and r[1] and r[1].body))
+end
+
+do
+    -- Non-file field value with a bare CR must survive into the parsed value
+    -- (byte-drop here would let an attacker hide a payload from ARGS scanning).
+    local body = build_body({
+        { cd_header = 'Content-Disposition: form-data; name="q"', body = "foo\rbar<script>" },
+    })
+    local r, err = mp:parse(body, CT)
+    check("non-file value with bare CR → preserved (no evasion via dropped bytes)",
+          r and r[1] and r[1].body == "foo\rbar<script>",
+          "got body=" .. tostring(r and r[1] and r[1].body) .. " err=" .. tostring(err))
+end
+
+do
+    -- Bare CR embedded in a part HEADER line is framing → still rejected.
+    local body = '--X\r\nContent-Disposition: form-data; name="a"\rEVIL\r\n\r\nv\r\n--X--\r\n'
+    local r, err = mp:parse(body, CT)
+    check("bare CR in a header line → rejected",
+          r == nil and err and err:find("bare CR in multipart framing"),
+          "got: " .. tostring(err))
+end
+
+do
+    -- Bare CR embedded in the opening boundary line is framing → still rejected.
+    local body = '--X\rGARBAGE\r\nContent-Disposition: form-data; name="a"\r\n\r\nv\r\n--X--\r\n'
+    local r, err = mp:parse(body, CT)
+    check("bare CR in the boundary line → rejected",
+          r == nil and err and err:find("bare CR in multipart framing"),
+          "got: " .. tostring(err))
+end
+
+do
+    -- A bare CR right before the closing delimiter (framing desync attempt):
+    -- the delimiter never surfaces as a clean line, so the closing-boundary
+    -- gate rejects it. Either way the request is denied, never parsed 200.
+    local body = '--X\r\nContent-Disposition: form-data; name="a"\r\n\r\nvalue\r--X--\r\n'
+    local r, err = mp:parse(body, CT)
+    check("bare CR glued before closing delimiter → rejected",
+          r == nil and err ~= nil,
+          "got: " .. tostring(err))
+end
+
+-- ===========================================================================
 print("== Gap #5: require closing boundary (Bypass #4) ==")
 -- ===========================================================================
 

--- a/kong-plugin-karna-1.4.1-0.rockspec
+++ b/kong-plugin-karna-1.4.1-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.4.0-0"
+version = "1.4.1-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.4.0"
+  tag = "v1.4.1"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.4.0",
+  VERSION = "1.4.1",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/modules/ka_multipart.lua
+++ b/kong/plugins/karna/modules/ka_multipart.lua
@@ -1,5 +1,4 @@
 local re_match  = ngx.re.match
-local re_find   = ngx.re.find
 local _M = {}
 
 -- Escape Lua pattern metacharacters in an arbitrary string so it can be
@@ -68,9 +67,13 @@ _M.reject_filename_star = true
 -- Require RFC 2046 quoted-string form for CD parameter values. When on,
 -- `filename=backdoor.php` (unquoted) is rejected. Closes Bypass #3 / #8.
 _M.require_quoted_params = true
--- Require strict CRLF line separators in the body. Bare LF / bare CR
--- bypass classes (lenient backend accepts, strict WAF parses
--- differently). Closes Bypass #2.
+-- Require strict CRLF line separators on the multipart FRAMING (boundary
+-- lines, part headers, the header/body separator). A bare LF or bare CR in
+-- framing is a desync bypass class (a lenient backend accepts it and parses
+-- a different structure than a strict WAF). Closes Bypass #2. Inside opaque
+-- part content a bare LF / CR is data, not framing, so it's kept verbatim —
+-- binary uploads (an image carries thousands of raw 0x0D / 0x0A bytes) are
+-- not rejected.
 _M.strict_crlf = true
 -- Require the explicit closing `--<boundary>--` line. PHP accepts
 -- incomplete bodies; strict WAFs must reject. Closes Bypass #4.
@@ -131,27 +134,23 @@ function _M.parse(self, body, content_type)
     local boundary_start = "^%-%-" .. boundary_escaped .. ""
     local boundary_end = "^%-%-" .. boundary_escaped .. "%-%-$"
 
-    -- Gap #4: strict CRLF. RFC 2046 mandates `\r\n`; lenient backends accept a
-    -- bare `\n` and split the body differently from a strict WAF — a documented
-    -- desync class.
+    -- Gap #4: strict CRLF. RFC 2046 mandates `\r\n` on framing; lenient
+    -- backends accept a bare `\n` (or a bare `\r`) and split the body
+    -- differently from a strict WAF — a documented desync class.
     --
-    -- Bare CR (a `\r` not followed by `\n`) has no legitimate use in a form
-    -- body, so it's rejected outright with a single body-wide ngx.re scan
-    -- (PCRE, JIT-compiled + cached via the 'jo' flags — ~10x faster than the
-    -- interpreted Lua char-class scan, which was ~12% of multipart CPU on a
-    -- multi-KB body: jit.p, scn05 3x10KB).
-    --
-    -- Bare LF is NOT scanned body-wide: that rejected any uploaded text file
-    -- carrying Unix newlines (a `\n` inside opaque part content is just data,
-    -- not a desync). It's enforced inside the parse loop below instead, scoped
-    -- to the FRAMING only (boundary lines, headers, the header/body separator,
-    -- and the `\r\n` preceding every delimiter) where a bare LF really does
-    -- desync.
-    if self.strict_crlf then
-        if re_find(body, "\\r[^\\n]", "jo") or body:sub(-1) == "\r" then
-            return nil, "bare CR found in body (strict CRLF required)"
-        end
-    end
+    -- Neither bare LF nor bare CR is scanned body-wide. A body-wide bare-CR
+    -- scan used to live here, but it rejected every real binary upload: a
+    -- `\r` (0x0D) byte not followed by `\n` is ordinary data inside opaque
+    -- part content (a ~1 MB image carries thousands of them), not a desync,
+    -- so an image POST to e.g. Ghost's admin upload endpoint was blocked with
+    -- "bare CR found in body". The strict-CRLF requirement only matters on the
+    -- FRAMING — boundary lines, part headers, the header/body separator, and
+    -- the `\r\n` preceding every delimiter — where a lone LF or CR really can
+    -- make a lenient backend see a different structure. So both are enforced
+    -- inside the parse loop below, scoped to framing; inside a part body they
+    -- are kept verbatim (the loop splits on `\n` only, so an interior `\r` is
+    -- preserved rather than dropped — that is what keeps a bare CR hidden in a
+    -- non-file field value inside ARGS where it still gets inspected).
 
     -- Normalise trailing CRLF. The closing `--<boundary>--` line is
     -- often sent without a trailing `\r\n` (RFC 2046 allows it), but
@@ -161,7 +160,12 @@ function _M.parse(self, body, content_type)
         body = body .. "\r\n"
     end
 
-    -- split body by lines by "\r\n"
+    -- Split the body into lines on `\n`. We capture everything up to the next
+    -- `\n` (INCLUDING any `\r`), then peel a single trailing `\r` to recover
+    -- the logical line and whether it ended in CRLF (`cr`). Splitting on `\n`
+    -- only — not on `\r\n` — means an interior bare `\r` stays inside `line`
+    -- instead of being silently dropped, so a bare CR hidden in a non-file
+    -- field value survives into ARGS and gets inspected.
     local start_collecting_headers = false
     local start_collecting_body = false
     local start_boundary_found = false
@@ -171,21 +175,37 @@ function _M.parse(self, body, content_type)
     -- first_line guards the opening boundary, which has no preceding line.
     local prev_cr = "\r"
     local first_line = true
-    for line, cr in body:gmatch("([^\r\n]*)(\r?)\n") do
-        -- Strict CRLF, scoped to framing. A bare LF that terminates a boundary
-        -- line, a header line, the header/body separator, or the body just
-        -- before a delimiter is a desync vector (a strict backend wants
-        -- `\r\n--boundary`; a line-based parser accepts `\n--boundary`). Inside
-        -- opaque part content a bare LF is harmless, so a legit text-file
-        -- upload with Unix newlines passes.
+    for raw in body:gmatch("([^\n]*)\n") do
+        local cr, line
+        if #raw > 0 and raw:byte(#raw) == 13 then
+            cr = "\r"
+            line = raw:sub(1, -2)
+        else
+            cr = ""
+            line = raw
+        end
+        -- An interior `\r`: a bare CR that is NOT the trailing CRLF terminator.
+        local interior_cr = line:find("\r", 1, true) ~= nil
+        -- Strict CRLF, scoped to framing. A bare LF or bare CR that terminates
+        -- a boundary line, a header line, or the header/body separator (or a
+        -- bare CR embedded in any of them) is a desync vector (a strict
+        -- backend wants `\r\n--boundary`; a line-based parser accepts
+        -- `\n--boundary`). Inside opaque part content a bare LF / CR is
+        -- harmless data, so a legit text- or binary-file upload with Unix
+        -- newlines or raw 0x0D bytes passes.
         if self.strict_crlf then
             local is_bnd = line:match(boundary_start) or line:match(boundary_end)
             local in_body = start_collecting_body
+            -- framing = anything that isn't opaque (non-boundary) part content
+            local is_framing = not (in_body and not is_bnd)
             if is_bnd and not first_line and prev_cr ~= "\r" then
                 return nil, "bare LF before boundary delimiter (strict CRLF required on framing)"
             end
-            if not (in_body and not is_bnd) and cr ~= "\r" then
+            if is_framing and cr ~= "\r" then
                 return nil, "bare LF in multipart framing (strict CRLF required)"
+            end
+            if is_framing and interior_cr then
+                return nil, "bare CR in multipart framing (strict CRLF required)"
             end
         end
         if line:match(boundary_end) then
@@ -202,7 +222,7 @@ function _M.parse(self, body, content_type)
             if self.debug then print("> START OF PART") end
             start_boundary_found = true
             part_count = part_count + 1
-            t[part_count] = {raw_headers="",body=""}
+            t[part_count] = {raw_headers="",body="",body_buf={}}
             start_collecting_headers = true
             start_collecting_body = false
         end
@@ -213,7 +233,11 @@ function _M.parse(self, body, content_type)
         end
         if start_collecting_body then
             if self.debug then print("> BODY LINE: " .. line) end
-            t[part_count].body = t[part_count].body .. line .. "\r\n"
+            -- Buffer body lines; join once after the loop. Per-line string
+            -- concatenation here was O(n^2) on the line count (a large file
+            -- upload, or a body padded with newlines, is thousands of lines).
+            local body_buf = t[part_count].body_buf
+            body_buf[#body_buf + 1] = line
         end
 
 
@@ -244,18 +268,22 @@ function _M.parse(self, body, content_type)
     for i, part in ipairs(t) do
         t[i].boundary = boundary
 
-        -- A well-formed part body is delimited by CRLF--boundary, so the raw
-        -- collected body is never empty: even an empty field carries its
-        -- delimiter CRLF (raw body == "\r\n"). An empty raw body means the
-        -- boundary was glued straight onto the headers terminator with no body
-        -- section (or the headers were never terminated) — a malformed part
-        -- the backend and the WAF parse differently. Reject the whole body.
-        if self.reject_bodyless_part and t[i].body == "" then
+        -- A well-formed part body is delimited by CRLF--boundary, so at least
+        -- one body line is always collected: even an empty field carries its
+        -- delimiter CRLF. Zero collected lines means the boundary was glued
+        -- straight onto the headers terminator with no body section (or the
+        -- headers were never terminated) — a malformed part the backend and
+        -- the WAF parse differently. Reject the whole body.
+        if self.reject_bodyless_part and #t[i].body_buf == 0 then
             return nil, "malformed part (no body section; boundary glued to headers) in part " .. tostring(i)
         end
 
-        -- remove last \r\n from body
-        t[i].body = t[i].body:sub(1, -3)
+        -- Materialise the buffered body. Each collected line used to be stored
+        -- with a trailing "\r\n" and the final one stripped by sub(1,-3);
+        -- joining with "\r\n" reproduces exactly that normalised framing (no
+        -- trailing separator) in O(n) instead of O(n^2).
+        t[i].body = table.concat(t[i].body_buf, "\r\n")
+        t[i].body_buf = nil
         t[i].content_length = #t[i].body
 
         -- remove last \r\n\r\n from raw_headers

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.4.0",
+  version      = "1.4.1",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.4.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.4.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
## What

A production false positive: image uploads to Ghost's admin endpoint
(`POST /ghost/api/admin/images/upload/`) were blocked with
`request_body_parser_violation` — "bare CR found in body (strict CRLF required)".

Root cause is in the multipart parser. A body-wide scan rejected any `\r`
(0x0D) not followed by `\n` **anywhere** in the body, including opaque part
content. A ~1 MB image carries thousands of raw 0x0D bytes as ordinary data,
so the block was effectively systematic on every real binary upload. The
sibling check for bare LF had already been scoped to framing for exactly this
reason; bare CR was left behind.

## Change

- Strict-CRLF enforcement is now scoped to the multipart **framing** (boundary
  lines, part headers, header/body separator), matching bare-LF handling.
  Inside a part body a bare CR/LF is kept verbatim. A bare CR embedded in
  framing is still rejected.
- The line loop splits on `\n` only instead of `\r\n`, so an interior `\r` is
  preserved rather than dropped. This closes a byte-drop evasion: a payload
  placed after a bare CR in a non-file field value used to be silently dropped
  and skip ARGS inspection.
- Part-body reconstruction now buffers lines and joins once — O(n) instead of
  O(n²) — which also removes a pre-existing newline-flood DoS (a body padded
  with newlines used to cost seconds of worker CPU).

## Tests

- `ka-unittest/multipart_security_gaps.lua`: +5 cases, 23/23 pass. New cases:
  binary file with bare CR accepted and bytes preserved; non-file value with
  bare CR preserved (no evasion); bare CR in a header line and in a boundary
  line still rejected.
- CRS PL1 regression **unchanged: 2757/2757**; `922-MULTIPART` 36/36.
- Live dev stack: image-with-bare-CR now **200** (was 403); SQLi in a text
  field still **403** (rule 942100); bare CR in framing still **403**
  (`request_body_parser_violation`).
- Real 1.2 MB binary parse: ~5 ms, no bytes lost (only the pre-existing
  LF→CRLF normalization used for internal inspection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
