### PR TITLE
chore: repo hygiene + CRS-plugins inventory API + seclang popen hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,12 @@ private/
 bench/
 # Generated WAF evaluation reports (not source)
 tests/reports/
+
+# Local work-in-progress (not for commit)
+dashboard/
+plans/
+
+# Agent tooling mirrors, kept local for now (the canonical copies live under
+# .claude/). AGENTS.md mirrors CLAUDE.md; .agents/ mirrors .claude/skills/.
+AGENTS.md
+.agents/

--- a/kong-plugin-karna-1.4.3-0.rockspec
+++ b/kong-plugin-karna-1.4.3-0.rockspec
@@ -25,6 +25,7 @@ build = {
   type = "builtin",
   modules = {
     ["kong.plugins."..pluginName..".handler"]         = "kong/plugins/"..pluginName.."/handler.lua",
+    ["kong.plugins."..pluginName..".api"]             = "kong/plugins/"..pluginName.."/api.lua",
     ["kong.plugins."..pluginName..".schema"]          = "kong/plugins/"..pluginName.."/schema.lua",
     ["kong.plugins."..pluginName..".version"]         = "kong/plugins/"..pluginName.."/version.lua",
     ["kong.plugins."..pluginName..".ka_engine"]       = "kong/plugins/"..pluginName.."/modules/ka_engine.lua",

--- a/kong/plugins/karna/api.lua
+++ b/kong/plugins/karna/api.lua
@@ -1,0 +1,102 @@
+local lfs = require "lfs"
+
+local kong = kong
+local sort = table.sort
+
+local DEFAULT_PLUGINS_PATH = "/opt/coreruleset-plugins/"
+local PLUGIN_NAME_PATTERN = "^[A-Za-z0-9][A-Za-z0-9._-]*$"
+
+
+local function normalized_root(path)
+  if type(path) ~= "string" or path == "" or path:find("\0", 1, true) then
+    return DEFAULT_PLUGINS_PATH
+  end
+  if path:sub(-1) ~= "/" then
+    return path .. "/"
+  end
+  return path
+end
+
+
+local function directory_entries(path)
+  local ok, iterator, state = pcall(lfs.dir, path)
+  if not ok or not iterator then
+    return {}
+  end
+
+  local entries = {}
+  for entry in iterator, state do
+    if entry ~= "." and entry ~= ".." then
+      entries[#entries + 1] = entry
+    end
+  end
+  return entries
+end
+
+
+local function is_real_directory(path)
+  -- Do not follow symlinked plugin directories. An inventory endpoint should
+  -- describe the configured plugin root, not become a filesystem explorer.
+  if lfs.symlinkattributes(path, "mode") == "link" then
+    return false
+  end
+  return lfs.attributes(path, "mode") == "directory"
+end
+
+
+local function plugin_inventory(root)
+  local plugins = {}
+
+  for _, name in ipairs(directory_entries(root)) do
+    if name:match(PLUGIN_NAME_PATTERN) and name ~= "." and name ~= ".." then
+      local package_path = root .. name
+      local conf_path = package_path .. "/plugins"
+      if is_real_directory(package_path) and is_real_directory(conf_path) then
+        local conf_files = {}
+        for _, filename in ipairs(directory_entries(conf_path)) do
+          local full_path = conf_path .. "/" .. filename
+          if filename:match("%.conf$")
+             and lfs.symlinkattributes(full_path, "mode") ~= "link"
+             and lfs.attributes(full_path, "mode") == "file" then
+            conf_files[#conf_files + 1] = filename
+          end
+        end
+        sort(conf_files)
+        if #conf_files > 0 then
+          plugins[#plugins + 1] = {
+            name = name,
+            config_files = conf_files,
+            config_file_count = #conf_files,
+          }
+        end
+      end
+    end
+  end
+
+  sort(plugins, function(a, b) return a.name < b.name end)
+  return plugins
+end
+
+
+return {
+  ["/karna/crs-plugins/:plugin_id"] = {
+    resource = "karna-crs-plugins",
+
+    GET = function(self)
+      local plugin, err = kong.db.plugins:select({ id = self.params.plugin_id })
+      if err then
+        return kong.response.exit(500, { message = "Could not read plugin configuration" })
+      end
+      if not plugin or plugin.name ~= "karna" then
+        return kong.response.exit(404, { message = "Karna plugin not found" })
+      end
+
+      local root = normalized_root(plugin.config and plugin.config.crs_plugins_path)
+      return kong.response.exit(200, {
+        plugin_id = plugin.id,
+        path = root,
+        plugins = plugin_inventory(root),
+      })
+    end,
+  },
+}

--- a/kong/plugins/karna/modules/seclang.lua
+++ b/kong/plugins/karna/modules/seclang.lua
@@ -116,6 +116,12 @@ end
 -- the operator may declare a plugin name that isn't on disk yet
 -- (CI bootstrap, optional installs), and we'd rather load no
 -- rules than crash the access phase.
+local function shell_quote(value)
+    -- POSIX single-quote escaping. plugin_dir is configuration-controlled;
+    -- quote it as data so it can never append shell syntax to the `ls` call.
+    return "'" .. tostring(value):gsub("'", "'\"'\"'") .. "'"
+end
+
 function seclang.collect_plugin_conf_files(plugin_dir)
     if not plugin_dir or plugin_dir == "" then return {} end
     if not plugin_dir:match("/$") then plugin_dir = plugin_dir .. "/" end
@@ -124,7 +130,7 @@ function seclang.collect_plugin_conf_files(plugin_dir)
     -- io.popen here is fork+exec — acceptable because this only runs
     -- on the first request after a plugin-config change (cached in the
     -- handler-side LRU thereafter), not on every request.
-    local pfile = io.popen('ls -a "' .. plugin_dir .. '" 2>/dev/null')
+    local pfile = io.popen("ls -a -- " .. shell_quote(plugin_dir) .. " 2>/dev/null")
     if not pfile then return files end
 
     for filename in pfile:lines() do


### PR DESCRIPTION
Three small, independent changes, one commit each.

- **chore(gitignore)** — ignore the local agent-tooling mirrors `AGENTS.md` and `.agents/` (canonical copies live under `.claude/`); tidies the existing `dashboard/` + `plans/` WIP ignores.
- **security(seclang)** — `collect_plugin_conf_files` interpolated the CRS-plugin dir straight into `io.popen "ls -a \"...\""`, so a path with shell metacharacters (`$`, backtick, `"`) could break out. `plugin_dir` is config-derived (defence-in-depth, not a reachable injection), but the quoting was unsafe. Now uses POSIX single-quote escaping + `ls -a --`.
- **feat(api)** — `GET /karna/crs-plugins/:plugin_id`: read-only inventory of the CRS exclusion plugins under `crs_plugins_path` and their `.conf` names (for the dashboard). No symlink following, validated dir names (traversal blocked), parametrised DAO read, never exposes file contents.

Reviewed for quality + security before commit. No engine/detection code touched.