### PR TITLE
fix(auditlog): serialize empty per-match tags/matched_parts as [] not {}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Audit log v2: an empty per-match `tags` or `matched_parts` now serialises as
+  a JSON array `[]` instead of an object `{}`. cjson encodes an empty Lua table
+  as `{}`, so a match on a rule with no tags (e.g. a custom `rate_limit` rule)
+  emitted `"tags": {}`, and a match with no recorded parts emitted
+  `"matched_parts": {}`. A consumer that maps/iterates those fields (`.map` /
+  `.find`) would break on the object form. The top-level `matches` /
+  `external_matches` / `messages` arrays already used `cjson.empty_array` for
+  this reason; the per-match arrays now do too. Detection unchanged.
+
 ## [1.4.3] - 2026-07-24
 
 ### Fixed

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -634,6 +634,15 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
                 end
             end
 
+            -- Empty per-match arrays must serialise as JSON `[]`, not `{}`.
+            -- cjson encodes an empty Lua table as an object; a consumer that
+            -- maps/iterates the value then breaks (an empty `matched_parts`
+            -- or `tags` was arriving as `{}`). The top-level `matches` /
+            -- `external_matches` already use empty_array for this reason.
+            if #matched_parts == 0 then
+                matched_parts = cjson.empty_array
+            end
+
             -- determine action label
             -- precedence: sanitized > rate_limited > block > detect > log
             -- - sanitized: rule had fix_matched_parts and the engine
@@ -659,10 +668,16 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
                 end
             end
 
+            -- normalise tags the same way (nil / empty table → JSON `[]`)
+            local tags = rule.tags
+            if type(tags) ~= "table" or next(tags) == nil then
+                tags = cjson.empty_array
+            end
+
             matches[#matches + 1] = {
                 rule_id = tostring(rule.id or "0"),
                 message = rule.message or "",
-                tags = rule.tags or {},
+                tags = tags,
                 matched_parts = matched_parts,
                 action = action_label
             }


### PR DESCRIPTION
## What

An empty per-match `tags` or `matched_parts` in the v2 audit log was serialized as a JSON object `{}` instead of an array `[]`, because cjson encodes an empty Lua table as `{}`.

- A match on a rule with no tags (e.g. a custom `rate_limit` rule) emitted `"tags": {}`.
- A match with no recorded parts emitted `"matched_parts": {}`.

A consumer that maps/iterates those fields (`.map` / `.find`) then breaks on the object form.

## Fix

`ka_utils.lua:get_auditlog_v2` now emits `cjson.empty_array` (`[]`) for empty per-match `tags` and `matched_parts` — the same treatment the top-level `matches` / `external_matches` / `messages` arrays already use.

## Impact

- Detection path untouched (log-serialization only).
- CRS regression unchanged: **2757/2757 (100%)**, verified locally on the DEV stack.
- Verified empirically: a tag-less `rate_limit` match now logs `"tags": []`.
- No version bump — tracked under `[Unreleased]` in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)