### PR TITLE
docs(skill): add "log": true to the rate-limit recipe example

### DIFF
--- a/.claude/skills/karna/reference/recipes.md
+++ b/.claude/skills/karna/reference/recipes.md
@@ -43,9 +43,11 @@ Strip dangerous characters in place and let the request through:
 ```
 
 ## Rate-limit an endpoint
-Needs Redis (`redis_host`/`redis_port`). Caps per source IP:
+Needs Redis (`redis_host`/`redis_port`). Caps per source IP. Keep `"log": true`
+(local rules don't log unless asked) so the throttled 429s show up in the audit
+log:
 ```json
-{ "id": "rl-login", "phase": "access",
+{ "id": "rl-login", "phase": "access", "log": true,
   "conditions": [ { "op": "beginsWith", "value": "/api/login", "transform": [],
                     "variables": ["request.raw_path"] } ],
   "action": { "rate_limit": { "key": "%{remote_addr}", "limit": 5, "window_seconds": 60,


### PR DESCRIPTION
## What

The rate-limit recipe in the Karna skill omitted `"log": true`.

Local rules (`rules_request`) do **not** default `log` to true — only CRS and the global-rules pack do. So a copied rate-limit rule increments the Redis counter and returns 429, but the match never lands in the audit log; a dashboard/consumer reading `matches` then shows the throttled request as "allowed".

## Change

- Add `"log": true` to the example (matching the sanitize recipe above it).
- One-line prose note explaining why it's needed.

Docs-only. No engine change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)