### PR TITLE
release: v1.4.4 — global rules from disk, controls/detection split, request.path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.4.4] - 2026-07-29
+
 ### Added
 
 - Global rules from disk: set `KARNA_GLOBAL_RULES_PATH` to a `.json` file, or to

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,11 +114,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.4.3-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.4.4-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.4.3",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.4.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.4.3-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.4.3-0.rockspec:ro
+      - ../kong-plugin-karna-1.4.4-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.4.4-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
       # Pairs with KARNA_GLOBAL_RULES_PATH above (both commented out by default).
       # - ./global-rules.d:/etc/kong/karna/global-rules.d:ro

--- a/kong-plugin-karna-1.4.4-0.rockspec
+++ b/kong-plugin-karna-1.4.4-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.4.3-0"
+version = "1.4.4-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.4.3"
+  tag = "v1.4.4"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.4.3",
+  VERSION = "1.4.4",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.4.3",
+  version      = "1.4.4",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.4.3",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.4.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
Release chore for **v1.4.4**. No behaviour change beyond what already merged in #34 and #35 — this is the version bump plus the CHANGELOG section.

## What ships

- **Global rules from disk** (#34) — `KARNA_GLOBAL_RULES_PATH`, a `.json` file or a directory of `*.json` in filename order. Redis is no longer required to ship one rule pack to every service.
- **Controls / detection split** (#34) — blocking rules and CRS exclusions can share a pack in any order; exclusions are always evaluated first, on the multi-match path.
- **Disk-first merge with id dedup** (#34) — the hot Redis channel can add rules but cannot replace one deployed on disk.
- **`@pmFromFile` unsupported in global packs** (#34) — dropped with a warning instead of kept as a condition that can never match.
- **`request.path` resolvable in rule conditions** (#35) — it was published in the inspection table but had no resolver branch, so a rule targeting it silently never matched.
- **Audit log v2 empty arrays** — per-match `tags` / `matched_parts` serialise as `[]`, not `{}`.

## Version bump

All seven places that must move together: `version.lua`, `handler.lua`, rockspec `version` + `source.tag` + **filename**, `docker/Dockerfile` (`COPY` line + build-time stamp), dev compose rockspec mount, `scripts/install.sh` stamp. `grep -rn "1\.4\.3"` outside the CHANGELOG comes back empty.

## Verification on this branch

- `scripts/build.sh image` builds the **prod** target with the renamed rockspec: `kong-plugin-karna 1.4.4-0 is now installed`, `version.lua` stamped `1.4.4` with the real commit. This is the step the rockspec rename historically breaks, so it was run deliberately.
- Dev stack (which installs from the renamed mount via `luarocks make`) answers `{"engine":"karna","version":"1.4.4",...}` on `/.well-known/karna`.
- Unit suite 13/13 by exit code; CRS PL1 regression 2757/2757.

Note: the CHANGELOG link-reference block at the bottom of the file has been stale since 1.1.5 (no refs for 1.2.0 … 1.4.3), so this release does not add one either — cleaning up the whole block is a separate chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)