### PR TITLE
feat(engine): client-IP rule variables (remote_addr / forwarded_addr)

### DIFF
--- a/.claude/skills/karna/reference/rules.md
+++ b/.claude/skills/karna/reference/rules.md
@@ -58,6 +58,7 @@ banned" check placed first short-circuits the rest.
 - `request.file`, `request.body.multipart.filename`, `request.body.multipart.header.value`.
 - `request.header.referer.{path,query,scheme,host}`.
 - `response.status`, `response.header.value:<name>` / `.name:<name>`, `response.set_cookie.value` / `.name` (header_filter phase; resolvable in conditions).
+- `request.remote_addr` — client IP as seen on the transport (ModSec `REMOTE_ADDR`; same value as the `%{remote_addr}` macro). `request.forwarded_addr` — Kong's forwarded client (`X-Forwarded-For` walked back through Kong's `trusted_ips`, falling back to the peer when the header is absent or the peer is untrusted). Behind a CDN/LB use the second. Pair either with `ipMatch`.
 - `matched.value`, `group:<n>` (chain refs).
 - `tx:<name>` / `var:<name>` (CRS TX vars, e.g. `var:paranoia_level`).
 - `redis.<key>` — inspect a Redis key (read-only). Everything after `redis.` is the key name (macros allowed: `%{remote_addr}`, `%{request.method|host|scheme|path}`, `%{request_headers.X}`). The **operator picks the command**: `isSet`→EXISTS (ban/existence check; `negated:true`→absent), `eq`/`rx`/`contains`/`beginsWith`→GET+compare, `gt`/`lt`/`ge`/`le`→GET+numeric, `redis_sismember`→SISMEMBER, `redis_hexists`→HEXISTS. Needs `redis_inspect_enabled`. (Legacy `redis.key:<macro>` GET form is dead — use `redis.<key>`.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: lua ka-unittest/redis_inspect.lua
       - name: Global rules pack (file + Redis sources, dedup, controls split, HMAC, replay guard)
         run: lua ka-unittest/global_rules.lua
-      - name: URI variable resolvers (request.path vs raw_path vs path_with_query)
+      - name: URI + client-IP variable resolvers (path family, remote_addr vs forwarded_addr)
         run: lua ka-unittest/variable_resolution.lua
       - name: WordPress ctl target exclusion (ARGS:name body-param removal + namespace gate)
         run: lua ka-unittest/wordpress_target_exclusion.lua

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Client IP is now a rule variable. `request.remote_addr` is the address on the
+  transport — the ModSecurity `REMOTE_ADDR` equivalent, and the same value the
+  `%{remote_addr}` macro already resolved. `request.forwarded_addr` is Kong's
+  forwarded view: `X-Forwarded-For` walked back through Kong's `trusted_ips`,
+  falling back to the peer when the header is absent or the peer is not trusted —
+  the one an IP allow/deny list needs behind a CDN or load balancer. Both work
+  with `ipMatch` and in `%{}` macros (`set_log_fields`, `set_variable`, Redis
+  keys). `REMOTE_ADDR` was mapped in the SecLang parser but had no resolver
+  behind it, so every rule targeting the client IP silently never matched.
+
+### Changed
+
+- CRS 905100 and 905110 (the Apache "common exceptions" — SSL pinger and internal
+  dummy connection) are now removed by `coreruleset_fix.lua`. Both chain
+  `REMOTE_ADDR @ipMatch 127.0.0.1,::1` with `ctl:ruleRemoveByTag=OWASP_CRS`, i.e.
+  they disable the entire rule set for a loopback-sourced request. They were
+  inert only because Karna resolved neither the variable nor the directive;
+  now that it resolves both, a Karna behind a local reverse proxy would be one
+  upstream change away from a ruleset-wide kill switch. Karna does not front
+  Apache, so the exceptions are dropped rather than left armed.
+
 ## [1.4.4] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -732,6 +732,8 @@ it for source installs. A plain `luarocks make` with no stamping reports
 | `request.body.multipart.header.value` | Multipart header values | n/a |
 | `request.raw_path` | Path component, not normalized, no querystring | `/t/Abc%20123/parent/..//test/./` |
 | `request.basename` | Last segment of the path | `/index.php?a=b` → `index.php` |
+| `request.remote_addr` | Client IP on the transport (`ngx.var.remote_addr`) — the ModSecurity `REMOTE_ADDR` equivalent, and the same value the `%{remote_addr}` macro resolves | `203.0.113.9` |
+| `request.forwarded_addr` | Client IP as Kong resolves it (`kong.client.get_forwarded_ip()`): `X-Forwarded-For` walked back through Kong's `trusted_ips` | `203.0.113.9` |
 | `response.set_cookie.name` | Array of cookie names from `Set-Cookie` | n/a |
 | `response.set_cookie.value` | Array of cookie values from `Set-Cookie` | n/a |
 
@@ -751,6 +753,43 @@ it for source installs. A plain `luarocks make` with no stamping reports
 | Variable | Description |
 | --- | --- |
 | `request.header_no_fp.value` | Request headers excluding the most FP-prone ones (User-Agent, Referer, etc.) |
+
+### Which client IP should a rule match?
+
+Both IP variables exist because the answer depends on your deployment, and
+getting it wrong is silent — an allow-list that matches nothing looks the same as
+one that was never reached.
+
+- **Karna directly exposed** → `request.remote_addr`. The transport peer *is* the
+  client.
+- **Karna behind a load balancer / CDN, with nginx `real_ip` configured** →
+  `request.remote_addr`. Setting `trusted_ips` in `kong.conf` makes nginx rewrite
+  `remote_addr` to the address from `X-Forwarded-For`, so the peer address is
+  already the real client and this is the simplest correct choice.
+- **Karna behind a proxy with no `real_ip` / `trusted_ips` configured** →
+  neither is the real client. `request.remote_addr` is the proxy, and
+  `request.forwarded_addr` falls back to the peer for exactly the same reason:
+  Kong refuses to believe an `X-Forwarded-For` from an untrusted hop. Configure
+  `trusted_ips` first — trusting the header without it is an IP-spoofing hole,
+  not a config detail.
+
+`request.forwarded_addr` is there for the case where you want Kong's forwarded
+view explicitly, independent of whether nginx rewrote `remote_addr`. Pair either
+with the `ipMatch` operator:
+
+```json
+{
+  "id": "allowlist-webhook-source",
+  "phase": "access",
+  "message": "webhook endpoint restricted to the provider's ranges",
+  "conditions": [
+    { "variables": ["request.raw_path"], "op": "beginsWith", "value": "/webhook/" },
+    { "variables": ["request.remote_addr"], "op": "ipMatch",
+      "value": "149.154.160.0/20,91.108.4.0/22", "negated": true }
+  ],
+  "action": { "fixed_response": { "status_code": 403, "body": "Forbidden\r\n" } }
+}
+```
 
 ## Supported operators
 

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -160,6 +160,8 @@
           <tr><td class="name"><code>request.path_with_query</code></td><td>Verbatim path plus the query string (CRS <code>REQUEST_URI</code>).</td></tr>
           <tr><td class="name"><code>request.basename</code></td><td>Last segment of the path (e.g. <code>index.php</code>).</td></tr>
           <tr><td class="name"><code>request.method</code></td><td>HTTP method.</td></tr>
+          <tr><td class="name"><code>request.remote_addr</code></td><td>Client IP as seen on the transport — the ModSecurity <code>REMOTE_ADDR</code> equivalent, and the same value the <code>%{remote_addr}</code> macro resolves. Pair with <code>ipMatch</code>.</td></tr>
+          <tr><td class="name"><code>request.forwarded_addr</code></td><td>Client IP as Kong resolves it: <code>X-Forwarded-For</code> walked back through Kong's <code>trusted_ips</code>, falling back to the peer address when the header is absent or the peer is not trusted. Behind a CDN or load balancer this is the one an IP allow/deny list needs.</td></tr>
           <tr><td class="name"><code>request.file</code></td><td>Uploaded file names / multipart param names.</td></tr>
           <tr><td class="name"><code>request.body.multipart.filename</code></td><td>Multipart filenames.</td></tr>
           <tr><td class="name"><code>request.body.multipart.header.value</code></td><td>Multipart part header values.</td></tr>

--- a/ka-unittest/variable_resolution.lua
+++ b/ka-unittest/variable_resolution.lua
@@ -55,8 +55,15 @@ local REQUEST = {
     path_with_query = "/x/../y?a=1",
 }
 
+-- Two distinct client IPs: the transport peer (a load balancer, say) and the
+-- forwarded client Kong derives from X-Forwarded-For + trusted_ips. They must
+-- not collapse into each other — an IP allow-list behind a CDN needs the second.
+local PEER_IP      = "10.0.0.7"
+local FORWARDED_IP = "203.0.113.9"
+
 _G.ngx = {
     get_phase = function() return PHASE end,
+    var = { remote_addr = PEER_IP },
 }
 _G.kong = {
     log = { err = function() end, warn = function() end, debug = function() end },
@@ -66,15 +73,27 @@ _G.kong = {
         get_path_with_query = function() return REQUEST.path_with_query end,
         get_method          = function() return "GET" end,
     },
+    client = {
+        get_forwarded_ip = function() return FORWARDED_IP end,
+    },
 }
 
 local ka_compile = dofile("./kong/plugins/karna/modules/ka_compile.lua")
 
--- Minimal engine stand-in: the resolvers for raw_path/basename delegate to
--- engine helpers, so provide just those.
+-- Minimal engine stand-in: the resolvers for raw_path/basename/the client-IP
+-- family delegate to engine helpers, so provide just those. These mirror the
+-- real getters in ka_engine.lua — if one is renamed there, the resolver calls a
+-- name this table does not have and the test errors out rather than passing on a
+-- stale stub.
 local engine = {
     __get_values_request_raw_path = function()
         return { ["request.raw_path"] = REQUEST.raw_path }, nil
+    end,
+    __get_values_remote_addr = function()
+        return { ["request.remote_addr"] = ngx.var.remote_addr }, nil
+    end,
+    __get_values_forwarded_addr = function()
+        return { ["request.forwarded_addr"] = kong.client.get_forwarded_ip() }, nil
     end,
 }
 
@@ -116,6 +135,33 @@ check("request.path_with_query keeps the querystring",
 local p  = resolve("request.path")["request.path"]
 local rp = resolve("request.raw_path")["request.raw_path"]
 check("path and raw_path stay distinct", p ~= rp, tostring(p) .. " vs " .. tostring(rp))
+
+-- ---------------------------------------------------------------------------
+print("")
+print("client IP variable resolvers:")
+-- ---------------------------------------------------------------------------
+
+-- SecLang maps REMOTE_ADDR to request.remote_addr, and that mapping existed for
+-- a long time with NO resolver behind it: every rule targeting the client IP
+-- (CRS 905100/905110, any IP allow/deny list) silently never matched. Exactly
+-- the failure mode this file exists to catch.
+values, why = resolve("request.remote_addr")
+check("request.remote_addr has a resolver", values ~= nil, tostring(why))
+check("request.remote_addr resolves the transport peer",
+      values and values["request.remote_addr"] == PEER_IP,
+      values and tostring(values["request.remote_addr"]))
+
+values, why = resolve("request.forwarded_addr")
+check("request.forwarded_addr has a resolver", values ~= nil, tostring(why))
+check("request.forwarded_addr resolves Kong's forwarded client",
+      values and values["request.forwarded_addr"] == FORWARDED_IP,
+      values and tostring(values["request.forwarded_addr"]))
+
+-- The whole point of shipping both: behind a proxy they differ, and a rule
+-- author picking one must not silently get the other.
+check("remote_addr and forwarded_addr stay distinct",
+      resolve("request.remote_addr")["request.remote_addr"]
+        ~= resolve("request.forwarded_addr")["request.forwarded_addr"])
 
 -- ---------------------------------------------------------------------------
 print("")

--- a/kong/plugins/karna/modules/ka_compile.lua
+++ b/kong/plugins/karna/modules/ka_compile.lua
@@ -412,6 +412,20 @@ function _M.compile_variable_resolver(variable)
         end
     end
 
+    -- request.remote_addr (transport peer) / request.forwarded_addr (X-Forwarded-For
+    -- walked back through Kong's trusted_ips). Both scalar and cheap, so the RE2
+    -- gate picks them up through this resolver too.
+    if variable == "request.remote_addr" then
+        return function(engine, rule)
+            return engine.__get_values_remote_addr()
+        end
+    end
+    if variable == "request.forwarded_addr" then
+        return function(engine, rule)
+            return engine.__get_values_forwarded_addr()
+        end
+    end
+
     -- request.header.value / request.header.value:<name>
     if variable == "request.header.value" then
         return function(engine, rule)

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -961,6 +961,49 @@ _M.__get_values_basename = function()
 
     return values, nil
 end
+-- Client IP, two flavours.
+--
+-- `request.remote_addr` is the transport peer — the same value ModSec's
+-- REMOTE_ADDR carries, the same value the `%{remote_addr}` macro resolves
+-- (`__resolve_reqctx_only`) and the same value `ignore_from_local_ips` matches
+-- on. Keeping all three on ngx.var.remote_addr means a rule and a rate-limit
+-- key never disagree about who the client is.
+--
+-- `request.forwarded_addr` is Kong's forwarded-IP view: X-Forwarded-For walked
+-- back through `trusted_ips`. Behind a CDN or load balancer the peer is the
+-- proxy, so an IP allow/deny list has to match on this one instead. It is
+-- Karna-native — SecLang has no equivalent variable.
+_M.__get_values_remote_addr = function()
+    if get_phase() == "init_worker" then
+        return {}, nil
+    end
+
+    local values = {}
+
+    local remote_addr = ngx.var.remote_addr
+    if remote_addr and remote_addr ~= "" then
+        values["request.remote_addr"] = remote_addr
+    end
+
+    return values, nil
+end
+_M.__get_values_forwarded_addr = function()
+    if get_phase() == "init_worker" then
+        return {}, nil
+    end
+
+    local values = {}
+
+    -- Kong resolves this from X-Forwarded-For honouring `trusted_ips`; it falls
+    -- back to the peer address when the header is absent or the peer is not
+    -- trusted, so there is no spoofing surface Kong hasn't already gated.
+    local ok, forwarded = pcall(kong.client.get_forwarded_ip)
+    if ok and forwarded and forwarded ~= "" then
+        values["request.forwarded_addr"] = forwarded
+    end
+
+    return values, nil
+end
 _M.__get_values_request_raw_query = function()
     if get_phase() == "init_worker" then
         return {}, nil
@@ -2605,6 +2648,12 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
 
                 if variable == "request.raw_query" then
                     values, err = self.__get_values_request_raw_query()
+                end
+
+                if variable == "request.remote_addr" then
+                    values, err = self.__get_values_remote_addr()
+                elseif variable == "request.forwarded_addr" then
+                    values, err = self.__get_values_forwarded_addr()
                 end
 
                 if variable == "request.header.value" then
@@ -4256,6 +4305,16 @@ _M.get_inspection_table = function(self, plugin_conf)
     end]]--
 
     table_insert(kong.ctx.plugin.inspection_table, {["remote_addr"] = tostring(ngx.var.remote_addr)})
+    -- Canonical `request.*` spellings of the two client-IP rule variables, so a
+    -- `%{request.remote_addr}` / `%{request.forwarded_addr}` macro in
+    -- set_log_fields / set_variable / a Redis key resolves to exactly what a
+    -- condition on the same variable saw. `remote_addr` above stays for the
+    -- historical macro spelling.
+    table_insert(kong.ctx.plugin.inspection_table, {["request.remote_addr"] = tostring(ngx.var.remote_addr)})
+    local _ok_fwd, _fwd = pcall(kong.client.get_forwarded_ip)
+    if _ok_fwd and _fwd then
+        table_insert(kong.ctx.plugin.inspection_table, {["request.forwarded_addr"] = tostring(_fwd)})
+    end
 
     local phase = get_phase()
 

--- a/kong/plugins/karna/rules/coreruleset_fix.lua
+++ b/kong/plugins/karna/rules/coreruleset_fix.lua
@@ -209,6 +209,22 @@ _M.global_fps = {
         log = false,
         conditions = {},
         unconditional_match_rule_control = {
+            -- Apache-only "common exceptions" that turn the WHOLE CRS off for a
+            -- request coming from 127.0.0.1 / ::1 (both chain on
+            -- `REMOTE_ADDR @ipMatch 127.0.0.1,::1` +
+            -- `ctl:ruleRemoveByTag=OWASP_CRS`):
+            --   905100 Apache SSL pinger        — cond1 is `REQUEST_LINE @streq "GET /"`,
+            --                                     i.e. an HTTP/0.9-style line
+            --   905110 Apache internal dummy connection — needs a User-Agent ending
+            --                                     in "(internal dummy connection)"
+            -- Neither shape can be produced through nginx, so they were already
+            -- inert — but Karna now resolves REMOTE_ADDR and honours
+            -- ctl:ruleRemoveByTag, so they are one upstream-proxy change away from
+            -- disabling the entire rule set for every loopback-sourced request.
+            -- Karna does not front Apache. Remove them rather than leave a
+            -- ruleset-wide kill switch armed behind a spoofable-looking predicate.
+            { remove_rule = { rule_id = "905100" } }, -- Apache SSL pinger exception
+            { remove_rule = { rule_id = "905110" } }, -- Apache internal dummy connection
             -- protocol well-formedness (nginx/Kong already enforce)
             { remove_rule = { rule_id = "920100" } }, -- Invalid HTTP Request Line
             { remove_rule = { rule_id = "920160" } }, -- Content-Length not numeric


### PR DESCRIPTION
`REMOTE_ADDR` was mapped in the SecLang parser but had **no resolver** behind it — not in the engine dispatcher, not in `ka_compile`. Any rule targeting the client IP resolved to nothing and never matched, silently. `@ipMatch` was implemented but had nothing to point at.

## What lands

| variable | source | when to use it |
| --- | --- | --- |
| `request.remote_addr` | `ngx.var.remote_addr` | Karna directly exposed, or behind an LB with nginx `real_ip` / `trusted_ips` configured (the peer is already the real client) |
| `request.forwarded_addr` | `kong.client.get_forwarded_ip()` | you want Kong's forwarded view explicitly — `X-Forwarded-For` walked back through `trusted_ips` |

`request.remote_addr` is the ModSecurity `REMOTE_ADDR` equivalent and stays consistent with the pre-existing `%{remote_addr}` macro and with `ignore_from_local_ips`, so a rule and a rate-limit key can never disagree about who the client is.

Both resolve in conditions and as `%{}` macros (`set_log_fields`, `set_variable`, Redis keys). Adding the `compile_variable_resolver` entry extends the RE2 gate for free **and soundly** — the gate resolves through the same function, so a rule gating on either variable stays gateable.

## Also: CRS 905100 / 905110 are dropped

Both are Apache-only "common exceptions" that chain `REMOTE_ADDR @ipMatch 127.0.0.1,::1` with `ctl:ruleRemoveByTag=OWASP_CRS` — they disable **the entire rule set** for a loopback-sourced request. They were inert only because Karna resolved neither the variable nor the directive.

This PR lands the variable half. The prune goes in the same PR, deliberately, so the exception is gone *before* a follow-up makes `ctl:ruleRemoveByTag` work and arms a ruleset-wide kill switch behind a predicate that looks spoofable. Karna does not front Apache, and no CRS regression test covers the 905 family.

In practice both were already hard to trigger — 905100 needs an HTTP/0.9-style request line that nginx rejects, 905110 needs the `(internal dummy connection)` User-Agent — but behind a local reverse proxy `remote_addr` is `127.0.0.1` for *all* traffic, so the margin was one upstream change wide.

## Verification

- CRS regression **2757/2757 (100%)** on the dev stack
- unit **16/16**; `variable_resolution.lua` extended to pin that each variable *has* a resolver (the exact regression this file exists to catch) and that the two stay distinct
- Lua syntax 19/19