### PR TITLE
feat(engine): per-request rule controls — DetectionOnly, ruleRemoveByTag, requestBodyAccess=Off

### DIFF
--- a/.claude/skills/karna/reference/rules.md
+++ b/.claude/skills/karna/reference/rules.md
@@ -91,7 +91,18 @@ A negated condition fires when the positive fails AND the value is present. Exce
 Macros for `key`/templates: `%{remote_addr}`, `%{request.method|host|scheme|path}`, plus any inspection-table var in `set_variable`/`set_log_fields`. Redis `redis.<key>` variables and `redis_set/sadd/del` keys/values also resolve `%{request_headers.X}`; the `redis_sismember`/`redis_hexists` needle (condition.value) resolves `%{remote_addr}`/`%{request.*}`/`%{request_headers.X}`.
 
 ## Rule controls (`rule_control[]` — modify this/other rules by id or tag)
-- `remove_rule` `{rule_id}` (range ok: `"920100-920199"`), `remove_rules_by_tag` `{tag}`.
+Per-request (a matching rule applies these to every rule evaluated after it — this is the `ctl:*` surface, and what a global-pack/local exclusion rule uses):
+- `remove_rule` `{rule_id}` (range ok: `"920100-920199"`) ← `ctl:ruleRemoveById`.
+- `remove_rules_by_tag` `{tag}` ← `ctl:ruleRemoveByTag`. Drops every rule carrying the tag.
+- `remove_target_from_rule_by_id` `{rule_id, target}` ← `ctl:ruleRemoveTargetById`.
+- `remove_target_rule_by_tag` `{tag, name}` ← `ctl:ruleRemoveTargetByTag`. Works on any tag. `tag: "OWASP_CRS"` is special-cased to mean **all rules** (custom ones included), not just CRS-tagged ones.
+- `engine_off: true` ← `ctl:ruleEngine=Off`. Skips all remaining rule evaluation.
+- `detection_only: true` ← `ctl:ruleEngine=DetectionOnly`. Rules still match, log, and run side effects; every terminal action is suppressed (`fixed_response`, the `rate_limit` 429, and `fix_matched_parts` sanitising). Audit log reports `engine.mode: "detection"` and `action: "detect"`.
+- `body_access_off: true` ← `ctl:requestBodyAccess=Off`. The request body stops being inspected: `request.body`, the parsed body namespaces (json/xml/urlencode/multipart/files) and the body half of `request.arg.value` all resolve empty; query args, path, headers and cookies are unaffected. `request.body.processor` stays set (it comes from Content-Type).
+
+**The always-on validation gates run before any rule control exists**, so none of these can switch off the method / path / header / content-type / body-parser / arg-count checks. Use the schema knobs for that.
+
+Load-time (applied once at worker start, used by `coreruleset_fix.lua`):
 - `remove_variable_from_rule_conditions` `{rule_id, variable_name}`.
 - `remove_variable_rx` `{name, rx}` — drop variables whose key matches a regex (libinjection header FPs).
 - `remove_target_rule_by_pattern` `{rule_id, pattern}`, `remove_target_tag_by_pattern` `{tag, pattern}`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
         run: lua ka-unittest/variable_resolution.lua
       - name: WordPress ctl target exclusion (ARGS:name body-param removal + namespace gate)
         run: lua ka-unittest/wordpress_target_exclusion.lua
+      - name: Per-request rule controls (tag removal, tag targets, DetectionOnly, body access)
+        run: lua ka-unittest/rule_control_runtime.lua
 
   leak-audit:
     name: Anti-leak audit (internal naming)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,25 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   with `ipMatch` and in `%{}` macros (`set_log_fields`, `set_variable`, Redis
   keys). `REMOTE_ADDR` was mapped in the SecLang parser but had no resolver
   behind it, so every rule targeting the client IP silently never matched.
+- Rule control `remove_rules_by_tag` (`ctl:ruleRemoveByTag=<tag>`): drop every
+  rule carrying a tag for the rest of the request. Previously this existed only
+  as a load-time control for `coreruleset_fix.lua`; the SecLang parser ignored
+  the directive outright, so a CRS exclusion plugin or a `custom_secrules` rule
+  using it did nothing.
+- Rule control `detection_only` (`ctl:ruleEngine=DetectionOnly`): rules keep
+  matching, logging and running their side effects, but every terminal action is
+  suppressed for that request — `fixed_response`, the `rate_limit` 429, and
+  `fix_matched_parts` sanitising. The audit log reports `engine.mode: "detection"`
+  and `action: "detect"` so the record matches what actually happened. Use it to
+  put one host or path in observe-only mode without a second Kong service.
+- Rule control `body_access_off` (`ctl:requestBodyAccess=Off`): stop inspecting
+  the request body for the rest of the request. `request.body`, the parsed body
+  namespaces (json / xml / urlencode / multipart / files) and the body half of
+  `request.arg.value` all resolve empty, while query args, path, headers and
+  cookies are still inspected; `request.body.processor` stays set because it
+  derives from `Content-Type`. Body-only rules are skipped outright rather than
+  walked to an empty result. Intended for file-upload endpoints where scanning
+  megabytes of payload buys nothing.
 
 ### Changed
 
@@ -29,7 +48,28 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   now that it resolves both, a Karna behind a local reverse proxy would be one
   upstream change away from a ruleset-wide kill switch. Karna does not front
   Apache, so the exceptions are dropped rather than left armed.
+- The three copies of the `rule_control` applier (two in `handler.lua`, one in
+  `ka_engine.lua`) are collapsed into one, in `ka_engine`. They had to be kept
+  byte-identical by hand, and a directive added to only one of them was a silent
+  no-op on the other paths.
 
+### Fixed
+
+- `engine_off` (`ctl:ruleEngine=Off`) set by a rule now stops the rest of the
+  rule list it was set from, not just the lists evaluated after it. `loop_rules`
+  only checked the flag on entry, so an exclusion living in `rules_request`
+  alongside detection rules bypassed the CRS as intended but let the remaining
+  local rules keep firing. The global pack never showed it, because its controls
+  run as a separate earlier pass and the entry check catches those.
+  `loop_rule_controls_pass` already broke mid-loop; the two now behave the same.
+- `remove_target_rule_by_tag` (`ctl:ruleRemoveTargetByTag=<tag>;<target>`) now
+  works for any tag. The reader was an unreferenced stub with a TODO, so only the
+  `OWASP_CRS` special case did anything and an exclusion written against, say,
+  `attack-sqli` was silently a no-op — the exact failure mode that keeps a false
+  positive alive while the config says it was excluded. Removal is name-based and
+  namespace-gated, identical to the by-id path, so an `ARGS`-scoped exclusion
+  still cannot silence a header or cookie of the same name. `tag: "OWASP_CRS"`
+  keeps its documented "all rules" meaning and its flat fast path.
 ## [1.4.4] - 2026-07-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -292,8 +292,21 @@ running on the WordPress admin path:
 }
 ```
 
-These use the same `ctl:ruleRemove*` controls as the plugins. See
-[Rule Control Functions](#rule-control-functions) for the full list.
+These use the same `ctl:*` controls as the plugins. The parser recognises:
+
+| SecLang directive | Effect |
+| --- | --- |
+| `ctl:ruleRemoveById=<id>` | Skip that rule. A hyphen range works too (`920100-920199`). |
+| `ctl:ruleRemoveByTag=<tag>` | Skip every rule carrying the tag. |
+| `ctl:ruleRemoveTargetById=<id>;<target>` | Drop one variable target from one rule. |
+| `ctl:ruleRemoveTargetByTag=<tag>;<target>` | Drop one variable target from every rule carrying the tag. |
+| `ctl:ruleEngine=Off` | Skip all remaining rule evaluation. |
+| `ctl:ruleEngine=DetectionOnly` | Match and log, suppress every terminal action. |
+| `ctl:requestBodyAccess=Off` | Stop inspecting the request body. |
+
+Anything else (`ctl:auditEngine`, `ctl:ruleRemoveByMsg`, …) is parsed and ignored
+rather than failing the rule. See [Rule Control Functions](#rule-control-functions)
+for the JSON equivalents and the semantics of each.
 
 ## Rate limiting
 
@@ -931,6 +944,30 @@ use `remove_variable_rx` rule controls:
 
 ## Rule Control Functions
 
+A rule's `rule_control` array modifies rules — itself or others, by id or by tag.
+There are two families, and the difference matters:
+
+**Per-request controls** are the `ctl:*` surface. When a rule carrying one
+matches, it applies to every rule evaluated *after* it in that request and
+nothing persists. This is what an exclusion rule in a global pack or in
+`rules_request` uses: `remove_rule`, `remove_rules_by_tag`,
+`remove_target_from_rule_by_id`, `remove_target_rule_by_tag`, `engine_off`,
+`detection_only`, `body_access_off`.
+
+**Load-time controls** rewrite the cached rule pack once at worker start. They
+are what `coreruleset_fix.lua` uses to patch FP-prone CRS rules:
+`change_rule_action`, `change_condition_tfunc`, `change_condition_value`,
+`replace_condition`, `remove_condition`, `add_condition`,
+`remove_variable_from_rule_conditions`, `remove_variable_rx`,
+`remove_target_rule_by_pattern`, `remove_target_tag_by_pattern`.
+
+> **The always-on validation gates cannot be reached from a rule control.** The
+> method, path, denied-header, content-type/charset, body-parser and
+> argument-count checks all run *before* the first rule is evaluated, so neither
+> `engine_off` nor `detection_only` nor `body_access_off` can switch them off. To
+> loosen those, use the plugin schema (`request_content_type_enforce`,
+> `limit_arg_num`, `request_methods_allowed`, …).
+
 ### `change_rule_action`
 
 ```json
@@ -1058,9 +1095,102 @@ use `remove_variable_rx` rule controls:
 
 ### `remove_rules_by_tag`
 
+Skip every rule carrying the tag. Per-request when applied from a matching rule
+(`ctl:ruleRemoveByTag`), load-time when declared in the CRS-fix pack.
+
 ```json
 "rule_control": [
     { "remove_rules_by_tag": { "tag": "injection" } }
+]
+```
+
+### `remove_target_from_rule_by_id`
+
+Drop one variable target from one rule, for this request only
+(`ctl:ruleRemoveTargetById=<id>;<target>`). The workhorse of CRS exclusions:
+whitelist one argument on one endpoint without disabling the rule everywhere.
+
+Removal is by field **name**, gated by namespace — so an `ARGS`-scoped exclusion
+can never silence a header or cookie that happens to share the name.
+
+```json
+"rule_control": [
+    {
+        "remove_target_from_rule_by_id": {
+            "rule_id": "942100",
+            "target": "request.arg.value:pwd"
+        }
+    }
+]
+```
+
+### `remove_target_rule_by_tag`
+
+Same, but for every rule carrying a tag (`ctl:ruleRemoveTargetByTag=<tag>;<target>`).
+
+`tag: "OWASP_CRS"` is special-cased to mean **all rules**, custom ones included —
+that is the historical meaning and it is also the cheap path (a flat list instead
+of walking the tag list of every rule). Any other tag scopes the removal to the
+rules actually carrying it.
+
+```json
+"rule_control": [
+    {
+        "remove_target_rule_by_tag": {
+            "tag": "attack-sqli",
+            "name": "request.header.value:user-agent"
+        }
+    }
+]
+```
+
+### `engine_off`
+
+Skip all remaining rule evaluation for this request (`ctl:ruleEngine=Off`). The
+bluntest instrument here: no rule fires, nothing is logged as a match.
+
+```json
+"rule_control": [
+    { "engine_off": true }
+]
+```
+
+### `detection_only`
+
+Turn this request into an observe-only one (`ctl:ruleEngine=DetectionOnly`), even
+on a service running with `engine_blocking_mode = true`. Rules keep matching,
+keep logging and keep running their side effects (`set_variable`,
+`set_log_fields`, `redis_*`); every **terminal** action is suppressed —
+`fixed_response`, the `rate_limit` 429, and `fix_matched_parts` sanitising.
+
+The audit log tells the truth about what happened: `engine.mode` reads
+`detection` and the match's `action` reads `detect` instead of `block`.
+
+Use it to put one host or one path in monitoring mode without standing up a
+second Kong service just to carry a different `engine_blocking_mode`.
+
+```json
+"rule_control": [
+    { "detection_only": true }
+]
+```
+
+### `body_access_off`
+
+Stop inspecting the request body for the rest of this request
+(`ctl:requestBodyAccess=Off`). `request.body`, every parsed body namespace
+(json / xml / urlencode / multipart / files) and the body half of
+`request.arg.value` all resolve empty. Query arguments, path, headers and cookies
+are **not** affected, and `request.body.processor` stays populated because it
+derives from `Content-Type`, not from the bytes.
+
+Rules that can only match on body variables are skipped outright rather than
+walked to an empty result, so this is also the cheap way to keep a file-upload
+endpoint from paying for a full scan of megabytes that will never match anything.
+
+```json
+"rule_control": [
+    { "body_access_off": true }
 ]
 ```
 

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -381,12 +381,17 @@
 
     <section id="rule-controls">
       <h2>Rule controls</h2>
-      <p>A rule's <code>rule_control</code> array modifies rules (itself or others by id / tag). Useful for carving out false positives and patching CRS rules without editing the pack.</p>
+      <p>A rule's <code>rule_control</code> array modifies rules (itself or others by id / tag). Useful for carving out false positives and patching CRS rules without editing the pack. When a rule carrying controls matches, they apply to every rule evaluated after it in the same request — this is the same surface SecLang exposes as <code>ctl:*</code>, and what an exclusion rule in a global pack or in <code>rules_request</code> uses.</p>
       <table class="doc-table">
         <thead><tr><th class="mono">Control</th><th>Effect</th></tr></thead>
         <tbody>
-          <tr><td class="name"><code>remove_rule</code></td><td>Skip a rule entirely (<code>{ "rule_id": "1234" }</code>).</td></tr>
-          <tr><td class="name"><code>remove_rules_by_tag</code></td><td>Skip all rules with a tag.</td></tr>
+          <tr><td class="name"><code>remove_rule</code></td><td>Skip a rule entirely (<code>{ "rule_id": "1234" }</code>); a hyphen range works too (<code>"920100-920199"</code>). ← <code>ctl:ruleRemoveById</code></td></tr>
+          <tr><td class="name"><code>remove_rules_by_tag</code></td><td>Skip every rule carrying a tag (<code>{ "tag": "attack-sqli" }</code>). ← <code>ctl:ruleRemoveByTag</code></td></tr>
+          <tr><td class="name"><code>remove_target_from_rule_by_id</code></td><td>Drop one variable target from one rule (<code>{ "rule_id": "942100", "target": "request.arg.value:pwd" }</code>). ← <code>ctl:ruleRemoveTargetById</code></td></tr>
+          <tr><td class="name"><code>remove_target_rule_by_tag</code></td><td>Drop one variable target from every rule carrying a tag (<code>{ "tag": "attack-sqli", "name": "request.header.value:user-agent" }</code>). <code>tag: "OWASP_CRS"</code> is special-cased to mean <em>all</em> rules, custom ones included. ← <code>ctl:ruleRemoveTargetByTag</code></td></tr>
+          <tr><td class="name"><code>engine_off</code></td><td><code>true</code> — skip all remaining rule evaluation for this request. ← <code>ctl:ruleEngine=Off</code></td></tr>
+          <tr><td class="name"><code>detection_only</code></td><td><code>true</code> — rules keep matching, logging and running side effects, but every terminal action is suppressed: <code>fixed_response</code>, the <code>rate_limit</code> 429, and <code>fix_matched_parts</code> sanitising. The audit log reports <code>engine.mode: "detection"</code> and <code>action: "detect"</code>. ← <code>ctl:ruleEngine=DetectionOnly</code></td></tr>
+          <tr><td class="name"><code>body_access_off</code></td><td><code>true</code> — stop inspecting the request body: <code>request.body</code>, the parsed body namespaces (json / xml / urlencode / multipart / files) and the body half of <code>request.arg.value</code> all resolve empty. Query args, path, headers and cookies are unaffected, and <code>request.body.processor</code> stays set (it derives from <code>Content-Type</code>). Useful on file-upload endpoints. ← <code>ctl:requestBodyAccess=Off</code></td></tr>
           <tr><td class="name"><code>remove_variable_from_rule_conditions</code></td><td>Drop a variable from every condition of a rule.</td></tr>
           <tr><td class="name"><code>remove_variable_rx</code></td><td>Drop variables whose key matches a regex (great for libinjection header FPs).</td></tr>
           <tr><td class="name"><code>remove_target_rule_by_pattern</code></td><td>Drop matched-key targets from a rule by Lua pattern.</td></tr>
@@ -397,6 +402,7 @@
           <tr><td class="name"><code>replace_condition</code> / <code>remove_condition</code> / <code>add_condition</code></td><td>Replace, delete, or append a condition.</td></tr>
         </tbody>
       </table>
+      <div class="note"><span class="lbl">Not reachable from a rule control</span>The always-on validation gates (method, path, denied headers, content-type / charset, body parser, argument count) run <em>before</em> any rule has been evaluated, so no control — not <code>engine_off</code>, not <code>detection_only</code>, not <code>body_access_off</code> — can switch them off. Loosen those through the plugin schema instead (<code>request_content_type_enforce</code>, <code>limit_arg_num</code>, <code>request_methods_allowed</code>, …).</div>
       <div class="code-card">
         <div class="code-head"><span>carve out libinjection header false positives</span><span class="lang">json</span></div>
         <div class="code-body"><pre><span class="prm">"rule_control"</span>: [

--- a/ka-unittest/rule_control_runtime.lua
+++ b/ka-unittest/rule_control_runtime.lua
@@ -1,0 +1,338 @@
+-- ka-unittest/rule_control_runtime.lua
+--
+-- Guards the per-request rule-control STORE and its readers — the half of the
+-- ctl:* pipeline that seclang_ctl_directives.lua does not cover (that one stops
+-- at "the parser emitted the right control table"; this one starts at "the
+-- applier wrote it into kong.ctx.plugin.rule_controls and the reader acted on
+-- it").
+--
+-- Three regressions are pinned here, all of the same silent-no-op family that
+-- made ctl:ruleRemoveTargetByTag on a non-OWASP_CRS tag dead for so long:
+--
+--   1. remove_rules_by_tag — the reader walks rule.tags only when
+--      `_has_removed_tags` is armed. That gate exists for perf (the reader runs
+--      once per rule per request, ~300 CRS rules deep), and a gate is exactly
+--      the kind of thing that silently disables a feature if the applier forgets
+--      to set it. Both directions are tested.
+--   2. remove_target_rule_by_tag on an arbitrary tag — routed through
+--      rule_controls.tags[<tag>].target and only applied to rules carrying that
+--      tag. OWASP_CRS keeps its own "all rules" fast path.
+--   3. detection_only vs engine_blocking_mode — which combinations let a
+--      terminal action through.
+--
+-- SUT is replicated inline (same convention as rule_overrides.lua,
+-- wordpress_target_exclusion.lua, set_variable_action.lua) so the test needs no
+-- kong/ngx globals. KEEP IN SYNC with:
+--   kong/plugins/karna/modules/ka_engine.lua  __apply_rule_controls_inline,
+--                                             __rule_control_rule_removed,
+--                                             the rc_tag_names collection in
+--                                             __match_rule_conditions_impl,
+--                                             remove_ctl_target
+--   kong/plugins/karna/handler.lua            detection_only_active,
+--                                             rule_blocking_enabled
+--
+-- Run from repo root:
+--   lua    ka-unittest/rule_control_runtime.lua
+--   luajit ka-unittest/rule_control_runtime.lua
+
+local string_find = string.find
+local string_sub  = string.sub
+
+local fails = 0
+local function ok(cond, name)
+    if cond then print("  ok  - " .. name)
+    else print("  FAIL- " .. name); fails = fails + 1 end
+end
+
+-- ============================================================
+-- SUT — the per-request store, as handler.lua:access initialises it
+-- ============================================================
+local function new_store()
+    return {
+        ids = {},
+        ids_targets = {},
+        tags = {},
+        removed_tags = {},
+        remove_target_from_all_rules = {},
+        engine_off = false,
+        detection_only = false,
+        body_access_off = false,
+    }
+end
+
+-- SUT — copy from ka_engine.lua:__apply_rule_controls_inline, with the
+-- kong.ctx.plugin indirection replaced by an explicit `rc` argument.
+local function apply_rule_controls(rc, controls)
+    if not controls or not rc then return end
+    for _, control in pairs(controls) do
+        if control.remove_rule and control.remove_rule.rule_id then
+            local id_spec = control.remove_rule.rule_id
+            local lo, hi = string.match(id_spec, "^(%d+)%-(%d+)$")
+            if lo and hi then
+                local lo_n, hi_n = tonumber(lo), tonumber(hi)
+                if lo_n and hi_n then
+                    for n = lo_n, hi_n do
+                        rc.ids[tostring(n)] = { action = "remove" }
+                    end
+                end
+            else
+                rc.ids[id_spec] = { action = "remove" }
+            end
+        end
+
+        if control.remove_target_from_rule_by_id then
+            local r = control.remove_target_from_rule_by_id
+            if r.rule_id and r.target then
+                if not rc.ids_targets[r.rule_id] then
+                    rc.ids_targets[r.rule_id] = {}
+                end
+                table.insert(rc.ids_targets[r.rule_id], r.target)
+            end
+        end
+
+        if control.remove_target_rule_by_tag and control.remove_target_rule_by_tag.tag then
+            local rt = control.remove_target_rule_by_tag
+            if rt.tag == "OWASP_CRS" then
+                table.insert(rc.remove_target_from_all_rules, rt.name)
+            else
+                if not rc.tags[rt.tag] then
+                    rc.tags[rt.tag] = { action = "remove_target", target = { rt.name } }
+                else
+                    table.insert(rc.tags[rt.tag].target, rt.name)
+                end
+                rc._has_tag_targets = true
+            end
+        end
+
+        if control.remove_rules_by_tag and control.remove_rules_by_tag.tag then
+            rc.removed_tags[control.remove_rules_by_tag.tag] = true
+            rc._has_removed_tags = true
+        end
+
+        if control.detection_only then rc.detection_only = true end
+        if control.body_access_off then rc.body_access_off = true end
+        if control.engine_off then rc.engine_off = true end
+    end
+end
+
+-- SUT — copy from ka_engine.lua:__rule_control_rule_removed
+local function rule_removed(rc, rule)
+    if rc.ids[rule.id] and rc.ids[rule.id]["action"] == "remove" then
+        return true
+    end
+    if rc._has_removed_tags and rule.tags then
+        for _, rule_tag in pairs(rule.tags) do
+            if rc.removed_tags[rule_tag] then return true end
+        end
+    end
+    return false
+end
+
+-- SUT — copy from ka_engine.lua:remove_ctl_target
+local function remove_ctl_target(values, target, variable)
+    if not values or type(target) ~= "string" then return end
+    if values[target] ~= nil then values[target] = nil end
+    local colon = string_find(target, ":", 1, true)
+    if not colon then return end
+    local t_ns   = string_sub(target, 1, colon - 1)
+    local t_name = string_sub(target, colon + 1)
+    if t_name == "" then return end
+    if type(variable) ~= "string" then return end
+    local vcolon = string_find(variable, ":", 1, true)
+    local var_ns = vcolon and string_sub(variable, 1, vcolon - 1) or variable
+    if t_ns ~= var_ns then return end
+    for k in pairs(values) do
+        if string_find(k, "%." .. t_name .. "$") or string_find(k, ":" .. t_name .. "$") then
+            values[k] = nil
+        end
+    end
+end
+
+-- SUT — copy from ka_engine.lua:__match_rule_conditions_impl, the rc_tag_names
+-- collection block, followed by the application loop.
+local function apply_tag_targets(rc, rule, values, variable)
+    local rc_tag_names
+    if rc._has_tag_targets and rule.tags then
+        for _, rule_tag in pairs(rule.tags) do
+            local entry = rc.tags[rule_tag]
+            if entry and entry.action == "remove_target" and entry.target then
+                for _, t in pairs(entry.target) do
+                    rc_tag_names = rc_tag_names or {}
+                    rc_tag_names[#rc_tag_names + 1] = t
+                end
+            end
+        end
+    end
+    if values and rc_tag_names then
+        for _, nm in pairs(rc_tag_names) do
+            remove_ctl_target(values, nm, variable)
+        end
+    end
+end
+
+-- SUT — copy from handler.lua
+local function detection_only_active(rc) return (rc and rc.detection_only) == true end
+local function rule_blocking_enabled(rc, engine_blocking_mode)
+    if not engine_blocking_mode then return false end
+    return not detection_only_active(rc)
+end
+
+local function has(values, k) return values[k] ~= nil end
+
+-- ============================================================
+print("- ctl:ruleRemoveByTag drops every rule carrying the tag")
+-- ============================================================
+local rc = new_store()
+apply_rule_controls(rc, { { remove_rules_by_tag = { tag = "attack-sqli" } } })
+
+ok(rc._has_removed_tags == true, "applier armed the _has_removed_tags gate")
+ok(rule_removed(rc, { id = "942100", tags = { "application-multi", "attack-sqli" } }),
+   "tagged rule is removed")
+ok(not rule_removed(rc, { id = "941100", tags = { "application-multi", "attack-xss" } }),
+   "differently-tagged rule survives")
+ok(not rule_removed(rc, { id = "930100", tags = nil }),
+   "rule with no tags at all survives (no crash on nil tags)")
+
+print("- OWASP_CRS as a removal tag takes the whole ruleset out")
+rc = new_store()
+apply_rule_controls(rc, { { remove_rules_by_tag = { tag = "OWASP_CRS" } } })
+ok(rule_removed(rc, { id = "942100", tags = { "OWASP_CRS", "attack-sqli" } }),
+   "CRS rule removed (the 905100 / 901450 shape)")
+ok(not rule_removed(rc, { id = "global-1", tags = { "global-pack" } }),
+   "an untagged-by-OWASP_CRS custom rule is NOT removed")
+
+-- The gate is a perf optimisation, so prove it is actually load-bearing: with
+-- removed_tags populated but the flag down, the reader must skip the walk. If
+-- this ever inverts, a forgotten flag becomes a silently disabled feature.
+print("- the _has_removed_tags gate is load-bearing")
+rc = new_store()
+rc.removed_tags["attack-sqli"] = true          -- populated WITHOUT the flag
+ok(not rule_removed(rc, { id = "942100", tags = { "attack-sqli" } }),
+   "gate down → no tag walk (applier must set the flag)")
+rc._has_removed_tags = true
+ok(rule_removed(rc, { id = "942100", tags = { "attack-sqli" } }),
+   "gate up → tag walk runs")
+
+-- ============================================================
+print("")
+print("- ctl:ruleRemoveTargetByTag on an arbitrary tag (was a silent no-op)")
+-- ============================================================
+rc = new_store()
+apply_rule_controls(rc, {
+    { remove_target_rule_by_tag = { tag = "attack-sqli", name = "request.header.value:user-agent" } },
+})
+ok(rc._has_tag_targets == true, "applier armed the _has_tag_targets gate")
+ok(rc.tags["attack-sqli"] ~= nil, "target filed under the tag, not the all-rules list")
+ok(#rc.remove_target_from_all_rules == 0, "non-OWASP_CRS tag did NOT go to the all-rules fast path")
+
+local sqli_rule = { id = "942100", tags = { "application-multi", "attack-sqli" } }
+local xss_rule  = { id = "941100", tags = { "application-multi", "attack-xss" } }
+
+local v = { ["request.header.value:user-agent"] = "' OR 1=1" }
+apply_tag_targets(rc, sqli_rule, v, "request.header.value")
+ok(not has(v, "request.header.value:user-agent"),
+   "UA target removed for the attack-sqli rule")
+
+v = { ["request.header.value:user-agent"] = "' OR 1=1" }
+apply_tag_targets(rc, xss_rule, v, "request.header.value")
+ok(has(v, "request.header.value:user-agent"),
+   "UA target SURVIVES for the attack-xss rule — the exclusion is tag-scoped")
+
+print("- multiple targets accumulate under one tag")
+rc = new_store()
+apply_rule_controls(rc, {
+    { remove_target_rule_by_tag = { tag = "attack-rce", name = "request.header.value:user-agent" } },
+    { remove_target_rule_by_tag = { tag = "attack-rce", name = "request.header.value:referer" } },
+})
+ok(#rc.tags["attack-rce"].target == 2, "both targets under attack-rce")
+v = { ["request.header.value:user-agent"] = "x",
+      ["request.header.value:referer"]    = "y",
+      ["request.header.value:host"]       = "z" }
+apply_tag_targets(rc, { id = "932100", tags = { "attack-rce" } }, v, "request.header.value")
+ok(not has(v, "request.header.value:user-agent"), "user-agent removed")
+ok(not has(v, "request.header.value:referer"),    "referer removed")
+ok(has(v, "request.header.value:host"),           "host untouched")
+
+print("- the namespace gate still holds for tag targets")
+rc = new_store()
+apply_rule_controls(rc, {
+    { remove_target_rule_by_tag = { tag = "attack-sqli", name = "request.arg.value:pwd" } },
+})
+v = { ["request.header.value:pwd"] = "' OR 1=1" }
+apply_tag_targets(rc, sqli_rule, v, "request.header.value")
+ok(has(v, "request.header.value:pwd"),
+   "an ARGS-scoped tag exclusion cannot silence a header of the same name")
+
+print("- the _has_tag_targets gate is load-bearing")
+rc = new_store()
+rc.tags["attack-sqli"] = { action = "remove_target", target = { "request.header.value:user-agent" } }
+v = { ["request.header.value:user-agent"] = "x" }
+apply_tag_targets(rc, sqli_rule, v, "request.header.value")
+ok(has(v, "request.header.value:user-agent"), "gate down → no removal")
+
+-- ============================================================
+print("")
+print("- ctl:ruleEngine=DetectionOnly vs engine_blocking_mode")
+-- ============================================================
+rc = new_store()
+ok(rule_blocking_enabled(rc, true),  "blocking service, no control → terminal actions fire")
+ok(not rule_blocking_enabled(rc, false), "detection service → terminal actions suppressed")
+
+apply_rule_controls(rc, { { detection_only = true } })
+ok(rc.detection_only == true, "applier set detection_only")
+ok(not rule_blocking_enabled(rc, true),
+   "blocking service + DetectionOnly → terminal actions suppressed")
+ok(detection_only_active(rc), "fix_matched_parts sanitising is suppressed too")
+
+-- engine_off is the stronger control and is stored independently: a request can
+-- be detection-only without being bypassed, and vice versa.
+print("- engine_off and detection_only are independent flags")
+rc = new_store()
+apply_rule_controls(rc, { { engine_off = true } })
+ok(rc.engine_off == true and rc.detection_only == false,
+   "engine_off alone does not imply detection_only")
+
+-- ============================================================
+print("")
+print("- ctl:requestBodyAccess=Off")
+-- ============================================================
+rc = new_store()
+ok(rc.body_access_off == false, "off by default")
+apply_rule_controls(rc, { { body_access_off = true } })
+ok(rc.body_access_off == true, "applier set body_access_off")
+
+-- The getters key their per-request cache on this flag rather than invalidating
+-- it, because the always-on body-parser gate warms the cache before any rule
+-- control exists. Pin the key derivation so a flipped flag can never read back
+-- a body-bearing entry.
+local function body_cache_key(rc_, try_b64)
+    if (rc_ and rc_.body_access_off) == true then
+        return try_b64 and "b64:nobody" or "raw:nobody"
+    end
+    return try_b64 and "b64" or "raw"
+end
+ok(body_cache_key(new_store(), false) == "raw", "normal request → raw")
+ok(body_cache_key(new_store(), true)  == "b64", "normal request, b64 → b64")
+ok(body_cache_key(rc, false) == "raw:nobody", "body_access_off → distinct key")
+ok(body_cache_key(rc, true)  == "b64:nobody", "body_access_off, b64 → distinct key")
+ok(body_cache_key(rc, false) ~= body_cache_key(new_store(), false),
+   "a warm pre-control entry can never be read back after the flag flips")
+
+-- ============================================================
+print("")
+print("- controls accumulate across several matching exclusion rules")
+-- ============================================================
+-- The controls path is multi-match: every matching exclusion contributes. A
+-- second apply must not clobber the first.
+rc = new_store()
+apply_rule_controls(rc, { { remove_rule = { rule_id = "920170" } } })
+apply_rule_controls(rc, { { remove_rules_by_tag = { tag = "attack-sqli" } },
+                          { detection_only = true } })
+apply_rule_controls(rc, { { remove_rule = { rule_id = "932260" } } })
+ok(rule_removed(rc, { id = "920170", tags = {} }), "first pass id removal survived")
+ok(rule_removed(rc, { id = "932260", tags = {} }), "third pass id removal applied")
+ok(rule_removed(rc, { id = "942100", tags = { "attack-sqli" } }), "tag removal applied")
+ok(rc.detection_only == true, "detection_only survived")
+
+print(string.format("\n%d test(s) failed", fails))
+os.exit(fails == 0 and 0 or 1)

--- a/ka-unittest/seclang_ctl_directives.lua
+++ b/ka-unittest/seclang_ctl_directives.lua
@@ -114,6 +114,67 @@ local cases = {
             ok(#controls == 0, "unknown ctl ignored")
         end,
     },
+    {
+        name = "ruleEngine=DetectionOnly",
+        actions = "id:9507108,phase:1,pass,nolog,ctl:ruleEngine=DetectionOnly",
+        check = function(controls)
+            local c = deep_find(controls, function(x) return x.detection_only == true end)
+            ok(c ~= nil, "detection_only=true emitted")
+            ok(deep_find(controls, function(x) return x.engine_off == true end) == nil,
+               "DetectionOnly does not also emit engine_off")
+        end,
+    },
+    {
+        -- Off is the stronger of the two; a rule declaring both must not end up
+        -- merely detection-only.
+        name = "ruleEngine=Off wins over =DetectionOnly",
+        actions = "id:9507109,phase:1,pass,nolog,ctl:ruleEngine=Off,ctl:ruleEngine=DetectionOnly",
+        check = function(controls)
+            ok(deep_find(controls, function(x) return x.engine_off == true end) ~= nil,
+               "engine_off emitted")
+            ok(deep_find(controls, function(x) return x.detection_only == true end) == nil,
+               "detection_only NOT emitted alongside engine_off")
+        end,
+    },
+    {
+        name = "ruleRemoveByTag",
+        actions = "id:9507110,phase:1,pass,nolog,ctl:ruleRemoveByTag=attack-sqli",
+        check = function(controls)
+            local c = deep_find(controls, function(x)
+                return x.remove_rules_by_tag and x.remove_rules_by_tag.tag == "attack-sqli"
+            end)
+            ok(c ~= nil, "remove_rules_by_tag.tag=attack-sqli")
+        end,
+    },
+    {
+        -- CRS 905100 / 905110 shape: remove the whole ruleset by its umbrella tag.
+        name = "ruleRemoveByTag=OWASP_CRS",
+        actions = "id:9507111,phase:1,pass,nolog,ctl:ruleRemoveByTag=OWASP_CRS,ctl:auditEngine=Off",
+        check = function(controls)
+            local c = deep_find(controls, function(x)
+                return x.remove_rules_by_tag and x.remove_rules_by_tag.tag == "OWASP_CRS"
+            end)
+            ok(c ~= nil, "remove_rules_by_tag.tag=OWASP_CRS")
+        end,
+    },
+    {
+        name = "requestBodyAccess=Off",
+        actions = "id:9507112,phase:1,pass,nolog,ctl:requestBodyAccess=Off",
+        check = function(controls)
+            local c = deep_find(controls, function(x) return x.body_access_off == true end)
+            ok(c ~= nil, "body_access_off=true emitted")
+        end,
+    },
+    {
+        -- =On is the default state: nothing to record, and emitting a control
+        -- would make an inert directive look like it did something.
+        name = "requestBodyAccess=On emits nothing",
+        actions = "id:9507113,phase:1,pass,nolog,ctl:requestBodyAccess=On",
+        check = function(controls)
+            ok(deep_find(controls, function(x) return x.body_access_off == true end) == nil,
+               "no body_access_off for =On")
+        end,
+    },
 }
 
 for _, case in ipairs(cases) do

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -366,54 +366,37 @@ end
 -- per-request `kong.ctx.plugin.rule_controls`. Extracted so both the
 -- standard evaluate_rules path (first-match-wins) and the CRS-plugins
 -- multi-match path can apply controls without duplicating dispatch.
+-- Single applier for `rule_control` side effects, in ka_engine so the engine's
+-- own inline call site (loop_rules, non-terminal matches) and the two handler
+-- call sites share one implementation. See
+-- ka_engine:__apply_rule_controls_inline for the directive list.
 local apply_rule_controls = function(controls)
-  if not controls then return end
-  for _, control in pairs(controls) do
-    if control.remove_rule and control.remove_rule.rule_id then
-      local id_spec = control.remove_rule.rule_id
-      local lo, hi = string.match(id_spec, "^(%d+)%-(%d+)$")
-      if lo and hi then
-        local lo_n, hi_n = tonumber(lo), tonumber(hi)
-        if lo_n and hi_n then
-          for n = lo_n, hi_n do
-            kong.ctx.plugin.rule_controls.ids[tostring(n)] = { action = "remove" }
-          end
-        end
-      else
-        kong.ctx.plugin.rule_controls.ids[id_spec] = { action = "remove" }
-      end
-    end
+  engine.__apply_rule_controls_inline(controls)
+end
 
-    if control.remove_target_from_rule_by_id then
-      local r = control.remove_target_from_rule_by_id
-      if r.rule_id and r.target then
-        if not kong.ctx.plugin.rule_controls.ids_targets[r.rule_id] then
-          kong.ctx.plugin.rule_controls.ids_targets[r.rule_id] = {}
-        end
-        table.insert(kong.ctx.plugin.rule_controls.ids_targets[r.rule_id], r.target)
-      end
-    end
+-- True when a rule has flipped this request to detection-only via
+-- ctl:ruleEngine=DetectionOnly. Detection-only means "observe, don't alter the
+-- transaction": rules still match, still run their side effects
+-- (set_variable / set_log_fields / redis_*) and still land in the audit log, but
+-- nothing that changes what upstream or the client sees is allowed to run.
+--
+-- Separate from `engine_blocking_mode` on purpose. `fix_matched_parts` has
+-- always sanitized regardless of the service's blocking mode, and that is not
+-- changed here — only the rule control suppresses it.
+local detection_only_active = function()
+  local rc = kong.ctx.plugin and kong.ctx.plugin.rule_controls
+  return (rc and rc.detection_only) == true
+end
 
-    if control.remove_target_rule_by_tag and control.remove_target_rule_by_tag.tag then
-      local rt = control.remove_target_rule_by_tag
-      if rt.tag == "OWASP_CRS" then
-        table.insert(kong.ctx.plugin.rule_controls.remove_target_from_all_rules, rt.name)
-      else
-        if not kong.ctx.plugin.rule_controls.tags[rt.tag] then
-          kong.ctx.plugin.rule_controls.tags[rt.tag] = {
-            action = "remove_target",
-            target = { rt.name }
-          }
-        else
-          table.insert(kong.ctx.plugin.rule_controls.tags[rt.tag].target, rt.name)
-        end
-      end
-    end
-
-    if control.engine_off then
-      kong.ctx.plugin.rule_controls.engine_off = true
-    end
-  end
+-- Terminal blocking (fixed_response, the rate_limit 429) fires only when the
+-- service is in blocking mode AND this request has not been flipped to
+-- detection-only.
+--
+-- Note the always-on validation gates in ka_engine read plugin_conf directly:
+-- they run before any rule control exists, so they cannot be turned off here.
+local rule_blocking_enabled = function(plugin_conf)
+  if not plugin_conf.engine_blocking_mode then return false end
+  return not detection_only_active()
 end
 
 -- Evaluate a pack of `pass`-action rules (CRS exclusion plugins +
@@ -495,9 +478,16 @@ local evaluate_rules = function(plugin_conf, rules, phase)
     -- removed. Takes precedence over `fixed_response` when both are
     -- declared on the same rule — sanitize wins because it preserves
     -- the user journey.
+    --
+    -- Under ctl:ruleEngine=DetectionOnly the strip is skipped: sanitizing is
+    -- disruptive (it rewrites what upstream receives), and detection-only means
+    -- observe without altering the transaction. The match is still logged, as
+    -- `detect` rather than `sanitized`.
     if rule_matched_obj.action and rule_matched_obj.action.fix_matched_parts and matches_info then
-      engine:__fix_matching_parts(rule_matched_obj, matches_info)
-      match_entry.sanitized = true
+      if not detection_only_active() then
+        engine:__fix_matching_parts(rule_matched_obj, matches_info)
+        match_entry.sanitized = true
+      end
       -- skip the block branch; sanitize already mutated the upstream
       -- request and the response should be whatever upstream returns.
       return
@@ -537,7 +527,7 @@ local evaluate_rules = function(plugin_conf, rules, phase)
       match_entry.rate_limit_key = full_key
       match_entry.rate_limited = (count ~= nil and limit > 0 and count > limit)
 
-      if plugin_conf.engine_blocking_mode and match_entry.rate_limited then
+      if rule_blocking_enabled(plugin_conf) and match_entry.rate_limited then
         local resp = rl.response or {}
         -- "ratelimit" variant: default_ratelimit_response_* slots between
         -- the rule's own response and the block-page defaults, so throttled
@@ -557,8 +547,8 @@ local evaluate_rules = function(plugin_conf, rules, phase)
       return
     end
 
-    -- if blocking mode enabled, exit with error
-    if plugin_conf.engine_blocking_mode then
+    -- if blocking mode enabled (and no ctl:ruleEngine=DetectionOnly), exit with error
+    if rule_blocking_enabled(plugin_conf) then
       if rule_matched_obj.action then
 
         if rule_matched_obj.action.fixed_response then
@@ -596,73 +586,11 @@ local evaluate_rules = function(plugin_conf, rules, phase)
       end
     end
 
+    -- A terminal rule can also carry rule_control (e.g. a blocking rule that
+    -- additionally drops a noisy CRS id). Same single applier the pass-rule path
+    -- and the engine's inline call site use.
     if rule_matched_obj.rule_control then
-      for _,control in pairs(rule_matched_obj.rule_control) do
-
-        if control.remove_rule then
-          if control.remove_rule.rule_id then
-            -- `rule_id` can be a single id ("920273") or a hyphen-range
-            -- ("9507100-9507999") — CRS exclusion plugins use ranges to
-            -- disable the entire id block when the plugin is opted out.
-            local id_spec = control.remove_rule.rule_id
-            local lo, hi = string.match(id_spec, "^(%d+)%-(%d+)$")
-            if lo and hi then
-              local lo_n = tonumber(lo)
-              local hi_n = tonumber(hi)
-              if lo_n and hi_n then
-                for n = lo_n, hi_n do
-                  kong.ctx.plugin.rule_controls.ids[tostring(n)] = { action = "remove" }
-                end
-              end
-            else
-              kong.ctx.plugin.rule_controls.ids[id_spec] = { action = "remove" }
-            end
-          end
-        end
-
-        -- ctl:ruleRemoveTargetById=<id>;<target> — drop a specific
-        -- variable target from a specific rule, for this request only.
-        -- Used heavily by CRS exclusion plugins (wordpress, drupal, …)
-        -- to whitelist known-good arg/header names per app endpoint.
-        if control.remove_target_from_rule_by_id then
-          local r = control.remove_target_from_rule_by_id
-          if r.rule_id and r.target then
-            if not kong.ctx.plugin.rule_controls.ids_targets[r.rule_id] then
-              kong.ctx.plugin.rule_controls.ids_targets[r.rule_id] = {}
-            end
-            table.insert(kong.ctx.plugin.rule_controls.ids_targets[r.rule_id], r.target)
-          end
-        end
-
-        if control.remove_target_rule_by_tag then
-          if control.remove_target_rule_by_tag.tag then
-
-            -- this means remove all rules
-            if control.remove_target_rule_by_tag.tag == "OWASP_CRS" then
-              table.insert(kong.ctx.plugin.rule_controls.remove_target_from_all_rules, control.remove_target_rule_by_tag.name)
-            else
-              -- normal behavior
-              if not kong.ctx.plugin.rule_controls.tags[control.remove_target_rule_by_tag.tag] then
-                kong.ctx.plugin.rule_controls.tags[control.remove_target_rule_by_tag.tag] = {
-                  action = "remove_target",
-                  target = { control.remove_target_rule_by_tag.name }
-                }
-              else
-                table.insert(kong.ctx.plugin.rule_controls.tags[control.remove_target_rule_by_tag.tag].target, control.remove_target_rule_by_tag.name)
-              end
-            end
-
-          end
-        end
-
-        -- ctl:ruleEngine=Off — disable rule evaluation entirely for
-        -- this request. Used by CRS exclusion plugins on endpoints
-        -- that need to bypass the WAF (e.g. file-manager pages).
-        if control.engine_off then
-          kong.ctx.plugin.rule_controls.engine_off = true
-        end
-
-      end
+      apply_rule_controls(rule_matched_obj.rule_control)
     end
 
   end
@@ -851,12 +779,28 @@ function plugin:access(plugin_conf)
   --   tags[<tag>]                    = { action = "remove_target", target = [...] }
   --   remove_target_from_all_rules   = [target1, target2, …]  → drop globally for this request
   --   engine_off                     = bool                   → ctl:ruleEngine=Off; skips all subsequent rules
+  --   detection_only                 = bool                   → ctl:ruleEngine=DetectionOnly; rules still
+  --                                                             match and log, terminal actions suppressed
+  --   removed_tags[<tag>]            = true                   → ctl:ruleRemoveByTag; drop every rule
+  --                                                             carrying <tag> for this request
+  --   body_access_off                = bool                   → ctl:requestBodyAccess=Off; the request body
+  --                                                             is not inspected for the rest of the request
+  --   _has_removed_tags              = bool                   → gate for the per-rule tag walk (perf)
+  --   _has_tag_targets               = bool                   → gate for the per-rule tag-target walk (perf)
+  --
+  -- The always-on validation gates (method / path / headers / content-type /
+  -- body-parser / arg-count) run BEFORE this store exists, so no rule control —
+  -- engine_off, detection_only or body_access_off — can switch them off. To
+  -- loosen those, use the schema knobs.
   kong.ctx.plugin.rule_controls = {
     ids = {},
     ids_targets = {},
     tags = {},
+    removed_tags = {},
     remove_target_from_all_rules = {},
     engine_off = false,
+    detection_only = false,
+    body_access_off = false,
   }
 
   -- get the CRS rule pack (loaded from disk at init_worker)
@@ -1114,7 +1058,9 @@ function plugin:log(plugin_conf)
 
       if plugin_conf.auditlog_modsec then
         json_log["transaction"]["producer"] = {}
-        if plugin_conf.engine_blocking_mode then
+        -- ctl:ruleEngine=DetectionOnly reports as DetectionOnly here too, which
+        -- is exactly the ModSecurity label this field mirrors.
+        if rule_blocking_enabled(plugin_conf) then
           json_log["transaction"]["producer"]["secrules_engine"] = "Enabled"
         else
           json_log["transaction"]["producer"]["secrules_engine"] = "DetectionOnly"

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -148,6 +148,25 @@ local function request_has_body()
     return false
 end
 
+-- ctl:requestBodyAccess=Off, set by a rule control earlier in this request.
+-- Read by the three body getters and by the two rule loops.
+--
+-- The getters fold this into their CACHE KEY rather than clearing the cache: the
+-- always-on `check_request_body_parser` gate parses the body before any rule
+-- control exists, so by the time the flag flips the "raw"/"b64" entries are
+-- already warm. A distinct key means a flag set halfway through a request is
+-- still honoured, with no invalidation logic to get wrong.
+local function body_access_off()
+    local rc = kong.ctx and kong.ctx.plugin and kong.ctx.plugin.rule_controls
+    return (rc and rc.body_access_off) == true
+end
+local function body_cache_key(try_b64)
+    if body_access_off() then
+        return try_b64 and "b64:nobody" or "raw:nobody"
+    end
+    return try_b64 and "b64" or "raw"
+end
+
 local response_get_headers              = kong.service.response.get_headers
 local response_get_status               = kong.service.response.get_status
 local response_exit                     = kong.response.exit
@@ -563,7 +582,7 @@ _M.__get_values_request_body = function(try_b64)
     end
 
     -- cache lookup: avoid re-parsing the body on every condition that reads it
-    local cache_key = try_b64 and "b64" or "raw"
+    local cache_key = body_cache_key(try_b64)
     if kong.ctx.plugin then
         if not kong.ctx.plugin.body_values_cache then
             kong.ctx.plugin.body_values_cache = {}
@@ -577,7 +596,10 @@ _M.__get_values_request_body = function(try_b64)
     local result_values = values
     local result_err = nil
 
-    if request_has_body() then
+    -- ctl:requestBodyAccess=Off — the body exists but is not inspected. Every
+    -- body namespace (urlencoded / json / xml / multipart / files) resolves
+    -- empty, which also takes the body out of the merged ARGS map below.
+    if request_has_body() and not body_access_off() then
 
         -- get request body
         local request_body = request_get_raw_body()
@@ -703,8 +725,16 @@ _M.__get_values_request_body_scalars = function()
         return {}
     end
 
-    if kong.ctx.plugin and kong.ctx.plugin.body_scalars_cache then
-        return kong.ctx.plugin.body_scalars_cache
+    -- Keyed like the other two body getters so ctl:requestBodyAccess=Off gets its
+    -- own entry rather than reading back a warm one that still carries the body.
+    local scalars_key = body_cache_key(false)
+    if kong.ctx.plugin then
+        if not kong.ctx.plugin.body_scalars_cache then
+            kong.ctx.plugin.body_scalars_cache = {}
+        end
+        if kong.ctx.plugin.body_scalars_cache[scalars_key] ~= nil then
+            return kong.ctx.plugin.body_scalars_cache[scalars_key]
+        end
     end
 
     local values = {}
@@ -733,7 +763,11 @@ _M.__get_values_request_body_scalars = function()
             end
         end
     end
-    if request_has_body() then
+    -- `request.body.processor` above stays populated under
+    -- ctl:requestBodyAccess=Off — it is derived from Content-Type, not from the
+    -- bytes, and CRS helper rules key ctl gates off it. The raw body and its
+    -- length are what the control suppresses.
+    if request_has_body() and not body_access_off() then
         local request_body = request_get_raw_body()
         if not request_body then
             local body_file = ngx_req_get_body_file()
@@ -764,7 +798,7 @@ _M.__get_values_request_body_scalars = function()
     end
 
     if kong.ctx.plugin then
-        kong.ctx.plugin.body_scalars_cache = values
+        kong.ctx.plugin.body_scalars_cache[scalars_key] = values
     end
     return values
 end
@@ -846,7 +880,10 @@ _M.__get_values_request_args = function (self, try_b64, rule_control)
     -- branch on top of the cached base, which is still cheaper than
     -- rebuilding from scratch.
     local has_ignore = (rule_control and rule_control.ignore_variables) and true or false
-    local cache_key = try_b64 and "b64" or "raw"
+    -- body_cache_key so a request flipped to ctl:requestBodyAccessOff gets its own
+    -- merged map (query only) instead of reading back one that still has the body
+    -- args folded in.
+    local cache_key = body_cache_key(try_b64)
     if kong.ctx.plugin then
         if not kong.ctx.plugin.args_values_cache then
             kong.ctx.plugin.args_values_cache = {}
@@ -1149,13 +1186,20 @@ end
 
 
 
--- Apply the side-effects of a non-terminal pass-rule's `rule_control`
--- list onto the per-request `kong.ctx.plugin.rule_controls` store.
--- Called inline by `loop_rules` when a matched rule has only side
--- effects (no fixed_response / fix_matched_parts / rate_limit) so a
--- later rule iteration in the same pass sees the accumulated state.
--- Mirrors handler.lua:apply_rule_controls but lives in the engine
--- module so the engine doesn't need a callback indirection.
+-- Apply the side-effects of a matched rule's `rule_control` list onto the
+-- per-request `kong.ctx.plugin.rule_controls` store.
+--
+-- THE single applier. It used to exist in three copies (this one, plus
+-- `apply_rule_controls` and an inline block in `evaluate_rules`, both in
+-- handler.lua) that had to be kept byte-identical by hand; adding a directive
+-- meant editing three places and a miss was a silent no-op on one path. Both
+-- handler.lua entry points now delegate here.
+--
+-- Called from:
+--   * loop_rules, when a matched rule is non-terminal, so later iterations in
+--     the same pass see the accumulated state
+--   * handler.lua:apply_rule_controls (the pass-rule / exclusion path)
+--   * handler.lua:evaluate_rules (a terminal rule that also carries controls)
 _M.__apply_rule_controls_inline = function(controls)
     if not controls or not kong.ctx.plugin or not kong.ctx.plugin.rule_controls then
         return
@@ -1197,7 +1241,35 @@ _M.__apply_rule_controls_inline = function(controls)
                 else
                     table_insert(rc.tags[rt.tag].target, rt.name)
                 end
+                -- Arm the reader in __match_rule_conditions_impl. Without this
+                -- flag the tag walk there never runs (it is gated so benign
+                -- traffic doesn't pay for it).
+                rc._has_tag_targets = true
             end
+        end
+
+        -- ctl:ruleRemoveByTag=<tag> — drop every rule carrying <tag> for the rest
+        -- of this request. Read by __rule_control_rule_removed, which runs for
+        -- every rule of every request, hence the `_has_removed_tags` gate: with
+        -- no tag control armed the reader costs one boolean test instead of
+        -- walking ~10 tags across ~300 rules.
+        if control.remove_rules_by_tag and control.remove_rules_by_tag.tag then
+            rc.removed_tags[control.remove_rules_by_tag.tag] = true
+            rc._has_removed_tags = true
+        end
+
+        -- ctl:ruleEngine=DetectionOnly — keep matching and logging, suppress
+        -- every terminal action (fixed_response / rate_limit 429 /
+        -- fix_matched_parts). Read by handler.lua:rule_blocking_enabled.
+        if control.detection_only then
+            rc.detection_only = true
+        end
+
+        -- ctl:requestBodyAccess=Off — stop inspecting the request body. Read by
+        -- the body getters (which fold it into their cache key) and by the two
+        -- rule loops (a `_needs_body` rule is skipped outright).
+        if control.body_access_off then
+            rc.body_access_off = true
         end
 
         if control.engine_off then
@@ -1225,7 +1297,10 @@ _M.loop_rule_controls_pass = function(self, plugin_conf, raw_rules, phase)
     -- Body presence, resolved once: Content-Length > 0 mirrors the body
     -- parser's gate, so a _needs_body rule skipped here is behaviour-identical
     -- to letting it resolve an empty values-table and bail.
-    local has_body = request_has_body()
+    -- ctl:requestBodyAccess=Off makes the body invisible to rules, so it lands
+    -- here too: a body-only rule then cannot fire, and skipping it saves the
+    -- resolution instead of walking it to an empty result.
+    local has_body = request_has_body() and not body_access_off()
 
     -- ctl:ruleEngine=Off short-circuit: a previously-applied control
     -- in this same evaluator pass could have flipped this on. Respect
@@ -1264,8 +1339,15 @@ _M.loop_rules = function(self, plugin_conf, raw_rules, phase)
     -- set this when its match condition fired, signalling "skip the
     -- entire WAF for this request". Honor it by returning immediately
     -- — no rule fires, no audit log row, request flows through.
-    if kong.ctx.plugin and kong.ctx.plugin.rule_controls
-       and kong.ctx.plugin.rule_controls.engine_off then
+    --
+    -- `_rc` is also re-read per iteration below: a rule INSIDE this same list
+    -- can set engine_off (a `rules_request` exclusion, which gets no
+    -- controls/detection split — only the global pack does), and without the
+    -- per-iteration check the remaining rules of the list kept evaluating. The
+    -- global pack never hit it because its controls run as a separate earlier
+    -- pass, so the entry check above catches them; local rules did.
+    local _rc = kong.ctx.plugin and kong.ctx.plugin.rule_controls
+    if _rc and _rc.engine_off then
         return
     end
 
@@ -1304,7 +1386,9 @@ _M.loop_rules = function(self, plugin_conf, raw_rules, phase)
         -- parser's own gate (`__get_values_request_body`), so skipping such a
         -- rule here is behaviour-identical to letting it resolve an empty
         -- values-table and bail (CRS regression empty-diff confirmed).
-        local has_body = request_has_body()
+        -- ctl:requestBodyAccess=Off has the same effect on a body-only rule:
+        -- the body getters return empty, so the rule cannot fire either way.
+        local has_body = request_has_body() and not body_access_off()
 
         -- Per-service CRS ruleset-type switches (coreruleset_rulesets): a set of
         -- disabled category codes for THIS service, or nil when all enabled
@@ -1313,6 +1397,9 @@ _M.loop_rules = function(self, plugin_conf, raw_rules, phase)
         local crs_disabled = crs_disabled_categories(plugin_conf)
 
         for _,rule in pairs(raw_rules) do
+            -- A rule earlier in THIS list may have just flipped engine_off.
+            -- One local-field read per rule; mirrors loop_rule_controls_pass.
+            if _rc and _rc.engine_off then break end
             if rule._needs_body and not has_body then
                 goto continue
             end
@@ -2337,6 +2424,36 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
         end
     end
 
+    -- Per-request `ctl:ruleRemoveTargetByTag=<tag>;<target>` for a tag OTHER than
+    -- OWASP_CRS. The applier (handler.lua:apply_rule_controls /
+    -- __apply_rule_controls_inline) files those under
+    -- `rule_controls.tags[<tag>].target`; this is the only reader. Before this,
+    -- the reader was an unreferenced stub with a TODO, so every non-OWASP_CRS
+    -- tag exclusion was silently a no-op.
+    --
+    -- OWASP_CRS keeps its own fast path (`remove_target_from_all_rules`): every
+    -- CRS rule carries that tag, so routing it here would mean walking the tag
+    -- list of ~300 rules to reach the same answer a flat list already gives —
+    -- and it stays "all rules", custom ones included, which is the documented
+    -- historical behaviour.
+    --
+    -- Gated on `_has_tag_targets` so the normal request pays one boolean test:
+    -- this block runs per rule per request, and the tag walk is only worth
+    -- entering once some exclusion has actually registered a tag target.
+    local rc_tag_names
+    local _rc = kong.ctx and kong.ctx.plugin and kong.ctx.plugin.rule_controls
+    if _rc and _rc._has_tag_targets and rule.tags then
+        for _, rule_tag in pairs(rule.tags) do
+            local entry = _rc.tags[rule_tag]
+            if entry and entry.action == "remove_target" and entry.target then
+                for _, t in pairs(entry.target) do
+                    rc_tag_names = rc_tag_names or {}
+                    rc_tag_names[#rc_tag_names + 1] = t
+                end
+            end
+        end
+    end
+
 
     --[[
         ██╗██╗██╗    ██╗ █████╗ ██████╗ ███╗   ██╗██╗███╗   ██╗ ██████╗ ██╗██╗
@@ -3045,6 +3162,16 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                 end
                 if values and rc_remove_names then
                     for _, nm in pairs(rc_remove_names) do
+                        remove_ctl_target(values, nm, variable)
+                    end
+                end
+                -- ctl:ruleRemoveTargetByTag on a non-OWASP_CRS tag, collected at
+                -- the top of this function from rule_controls.tags for the tags
+                -- THIS rule carries. Same name-based, namespace-gated removal
+                -- the by-id and OWASP_CRS paths use, so an exclusion and a rule
+                -- always look at exactly the same keys.
+                if values and rc_tag_names then
+                    for _, nm in pairs(rc_tag_names) do
                         remove_ctl_target(values, nm, variable)
                     end
                 end
@@ -3798,25 +3925,29 @@ _M.__rule_control_rule_removed = function(self, rule)
                     end
                 end
             end
+
+            -- ctl:ruleRemoveByTag=<tag>. This function is on the hottest path
+            -- there is — called once per rule per request, ~300 CRS rules deep —
+            -- so the tag walk sits behind `_has_removed_tags`. With no tag
+            -- control armed (the overwhelmingly common case) the cost is a single
+            -- table lookup, not ~10 string compares per rule.
+            local rc = kong.ctx.plugin.rule_controls
+            if rc._has_removed_tags and rule.tags then
+                for _, rule_tag in pairs(rule.tags) do
+                    if rc.removed_tags[rule_tag] then
+                        return true
+                    end
+                end
+            end
         end
     end
     return false
 end
-_M.__rule_control_remove_target = function(self, rule)
-    if kong.ctx and kong.ctx.plugin then
-        if kong.ctx.plugin.rule_controls then
-            if kong.ctx.plugin.rule_controls.tags then
-                -- rule.tags -> table with all rule's tags
-                -- TODO: IMPLEMENT A WAY TO REMOVE FROM TAGS
-                -- 
-                -- change the "expected" behavior on OWASP_CRS
-                -- cause it means "remove all rules" and not remove that tag!
-                -- that's stupid and consume a lot of CPU instead of having
-                -- remove_all_rules meaning remove this <target variable> from all rules
-            end
-        end
-    end
-end
+-- (`__rule_control_remove_target` used to live here as an unreferenced stub with
+-- a TODO. Per-request `ctl:ruleRemoveTargetByTag` on a non-OWASP_CRS tag is now
+-- read inside __match_rule_conditions_impl, next to the by-id and
+-- remove_target_from_all_rules filtering, so exclusion and rule share one
+-- removal helper. See `rc_tag_names` there.)
 
 
 -- OLD

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -652,16 +652,24 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
             -- - rate_limited: rule had rate_limit and the Redis counter
             --   exceeded the configured limit (returned 429)
             -- - block: blocking mode + fixed_response → 403 returned
-            -- - detect: monitoring mode + fixed_response → 200 logged
+            -- - detect: monitoring mode (or ctl:ruleEngine=DetectionOnly) +
+            --   fixed_response → 200 logged
             -- - log: rule fired without a response action (pass / setvar
             --   / under-threshold rate_limit increment)
+            --
+            -- `rate_limited` is set by the handler only when the counter went
+            -- over; under DetectionOnly the 429 is suppressed but the counter
+            -- still tripped, so the label stays truthful about what the rule saw.
+            local detection_only = (kong.ctx.plugin
+                                    and kong.ctx.plugin.rule_controls
+                                    and kong.ctx.plugin.rule_controls.detection_only) == true
             local action_label = "log"
             if matched.sanitized then
                 action_label = "sanitized"
             elseif matched.rate_limited then
                 action_label = "rate_limited"
             elseif rule.action and rule.action.fixed_response then
-                if plugin_conf.engine_blocking_mode then
+                if plugin_conf.engine_blocking_mode and not detection_only then
                     action_label = "block"
                 else
                     action_label = "detect"
@@ -760,7 +768,13 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
             name = "karna",
             version = ka_version.version,
             commit = ka_version.commit,
-            mode = plugin_conf.engine_blocking_mode and "blocking" or "detection",
+            -- A rule that fired ctl:ruleEngine=DetectionOnly turns this request
+            -- into a detection-only one regardless of the service setting, so
+            -- report what actually applied.
+            mode = (plugin_conf.engine_blocking_mode
+                    and not (kong.ctx.plugin and kong.ctx.plugin.rule_controls
+                             and kong.ctx.plugin.rule_controls.detection_only))
+                   and "blocking" or "detection",
             paranoia_level = tonumber(plugin_conf.paranoia_level) or 1
         },
         matches = matches,

--- a/kong/plugins/karna/modules/seclang.lua
+++ b/kong/plugins/karna/modules/seclang.lua
@@ -714,25 +714,40 @@ end
 -- …) to whitelist app-specific param names / disable rules on known
 -- endpoints. Supported directives:
 --   ctl:ruleRemoveById=<id|range>            → drop the rule entirely
+--   ctl:ruleRemoveByTag=<tag>                → drop every rule tagged <tag>
 --   ctl:ruleRemoveTargetById=<id>;<target>   → drop one target from <id>
 --   ctl:ruleRemoveTargetByTag=<tag>;<target> → drop one target from rules tagged <tag>
 --   ctl:ruleEngine=Off                       → bypass WAF for this request
+--   ctl:ruleEngine=DetectionOnly             → match + log, suppress terminal actions
+--   ctl:requestBodyAccess=Off                → stop inspecting the request body
 -- Unrecognised directives are ignored (forward-compat with future CRS
 -- additions; matches our defensive parsing posture for malformed input).
 function seclang.__get_rule_controls(actions)
     local controls = {}
     if not actions or actions == "" then return controls end
 
-    -- ctl:ruleEngine=Off — must check before generic ctl: gmatch so
-    -- the casing is preserved and we can match the literal "Off".
+    -- ctl:ruleEngine=Off / =DetectionOnly — matched before the generic ctl:
+    -- gmatch so the casing is preserved and the literal value is checked.
+    -- `Off` is the stronger of the two, so it wins if a rule somehow declares
+    -- both.
     if actions:match("ctl:ruleEngine%s*=%s*Off") then
         table.insert(controls, { engine_off = true })
+    elseif actions:match("ctl:ruleEngine%s*=%s*DetectionOnly") then
+        table.insert(controls, { detection_only = true })
+    end
+
+    -- ctl:requestBodyAccess=Off — same reason: the literal value matters.
+    -- `=On` is the default state, so there is nothing to record for it.
+    if actions:match("ctl:requestBodyAccess%s*=%s*Off") then
+        table.insert(controls, { body_access_off = true })
     end
 
     for directive_arg in actions:gmatch("ctl:([^,]+)") do
         local name, rhs = directive_arg:match("^([%w_]+)%s*=%s*(.+)$")
         if name and rhs then
-            if name == "ruleRemoveById" then
+            if name == "ruleRemoveByTag" then
+                table.insert(controls, { remove_rules_by_tag = { tag = rhs } })
+            elseif name == "ruleRemoveById" then
                 -- rhs is either "920100" or "920100-920199" — handler.lua
                 -- does the range expansion at request time.
                 table.insert(controls, { remove_rule = { rule_id = rhs } })


### PR DESCRIPTION
Three ModSecurity `ctl:` directives the SecLang parser recognised as text and then dropped, plus two silent no-ops in the same subsystem.

## New per-request controls

| control | `ctl:` equivalent | what it does |
| --- | --- | --- |
| `detection_only` | `ruleEngine=DetectionOnly` | rules keep matching, logging and running side effects; every terminal action is suppressed — `fixed_response`, the `rate_limit` 429, and `fix_matched_parts` sanitising |
| `remove_rules_by_tag` | `ruleRemoveByTag` | drop every rule carrying a tag for the rest of the request |
| `body_access_off` | `requestBodyAccess=Off` | stop inspecting the request body |

`detection_only` also stops the audit log from lying: `engine.mode` reads `detection` and the match reads `action: "detect"`. It puts one host or path in observe-only mode without standing up a second Kong service to carry a different `engine_blocking_mode`.

`body_access_off` is scoped, not a blanket bypass: `request.body`, the parsed body namespaces (json / xml / urlencode / multipart / files) and the body half of `request.arg.value` resolve empty, while query args, path, headers and cookies are still inspected. `request.body.processor` stays populated because it derives from `Content-Type`, not from the bytes. Body-only rules are skipped outright rather than walked to an empty result, so an upload endpoint stops paying for a scan of megabytes that can never match.

## Two fixes

**`remove_target_rule_by_tag` now works for any tag.** The reader was an unreferenced stub with a TODO, so only the `OWASP_CRS` special case did anything — an exclusion written against `attack-sqli` was silently a no-op, which is the failure mode that keeps a false positive alive while the config claims it was excluded. Removal stays name-based and namespace-gated, identical to the by-id path, so an `ARGS`-scoped exclusion still cannot silence a header or cookie of the same name. `tag: "OWASP_CRS"` keeps its documented "all rules" meaning and its flat fast path.

**`engine_off` now stops the rest of the list it was set from.** `loop_rules` only checked the flag on entry, so an exclusion living in `rules_request` alongside detection rules bypassed the CRS as intended but let the remaining local rules keep firing. The global pack never showed it — its controls run as a separate earlier pass, so the entry check catches those. `loop_rule_controls_pass` already broke mid-loop; the two now agree.

## Implementation notes worth a reviewer's eye

- **Hot path.** The per-rule tag walks sit behind `_has_removed_tags` / `_has_tag_targets`. `__rule_control_rule_removed` runs once per rule per request across ~300 CRS rules, so with no tag control armed the cost is one boolean test rather than ~10 string compares per rule.
- **Cache keys, not invalidation.** The three body getters fold `body_access_off` into their cache key. The always-on body-parser gate parses the body *before* any rule control exists, so the `"raw"` / `"b64"` entries are already warm by the time the flag can flip. A distinct key is what makes a mid-request flip correct, with no invalidation logic to get wrong.
- **One applier.** The three hand-synchronised copies of the `rule_control` applier (two in `handler.lua`, one in `ka_engine`) are collapsed into one. Adding a directive to only one of them was a silent no-op on the other paths — which is precisely how the stub above survived. `handler.lua` gets ~70 lines shorter.
- **`fix_matched_parts` gating.** Suppressed by `detection_only` only, *not* by `engine_blocking_mode`. Sanitising has always run regardless of the service's blocking mode and that is left alone — changing it would be a behaviour change nobody asked for.

## Deliberately out of scope

The always-on validation gates (method, path, denied headers, content-type / charset, body parser, arg count) run before the control store exists, so no control — `engine_off`, `detection_only` or `body_access_off` — can switch them off. Documented rather than worked around; loosening those is what the schema knobs are for.

## Verification

- CRS regression **2757/2757 (100%)**
- unit **17/17**, including a new `rule_control_runtime.lua` (39 assertions) that pins the gate flags as load-bearing in both directions — a forgotten flag would otherwise silently disable a feature
- `seclang_ctl_directives.lua` extended for the three new directives, including `ruleEngine=Off` winning over `=DetectionOnly` and `requestBodyAccess=On` emitting nothing
- live-tested end to end on the dev stack: exclusion applies on its path and not elsewhere, a differently-tagged rule still fires after a tag-scoped target removal, and a query arg is still inspected under `body_access_off`