### PR TITLE
release: v1.5.0 — client-IP variables, per-request rule controls, log_only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-30
+
 ### Added
 
 - Client IP is now a rule variable. `request.remote_addr` is the address on the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,11 +114,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.4.4-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.5.0-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.4.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.5.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.4.4-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.4.4-0.rockspec:ro
+      - ../kong-plugin-karna-1.5.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.5.0-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
       # Pairs with KARNA_GLOBAL_RULES_PATH above (both commented out by default).
       # - ./global-rules.d:/etc/kong/karna/global-rules.d:ro

--- a/kong-plugin-karna-1.5.0-0.rockspec
+++ b/kong-plugin-karna-1.5.0-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.4.4-0"
+version = "1.5.0-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.4.4"
+  tag = "v1.5.0"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.4.4",
+  VERSION = "1.5.0",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.4.4",
+  version      = "1.5.0",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.4.4",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.5.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
Version bump only — every feature in this release landed in #37, #38 and #39.

## The six places the version lives

| where | what |
| --- | --- |
| `kong/plugins/karna/version.lua` | the source of truth |
| `kong/plugins/karna/handler.lua` | the `VERSION` constant (overwritten at load, bumped so a `grep` stays clean) |
| `kong-plugin-karna-1.5.0-0.rockspec` | **filename** + `version` + `source.tag` |
| `docker/Dockerfile` | the `COPY` of the rockspec **and** the build-time `version.lua` stamp |
| `docker/docker-compose.dev.yml` | the rockspec bind-mount (both sides) |
| `scripts/install.sh` | its `version.lua` stamp |

The rockspec rename is the one that bites: it breaks the `COPY` in the Dockerfile and the dev-compose mount, and CI then fails at image build rather than at a test. `grep -rn "1.4.4"` comes back clean except for the CHANGELOG history.

## Also closes the CHANGELOG

The nine entries the three feature PRs accumulated under `[Unreleased]` move to `[1.5.0] - 2026-07-30`, with a fresh empty `[Unreleased]` left behind.

## Verification

Verified on the dev stack with 1.5.0 actually serving (`GET /.well-known/karna` → `"version": "1.5.0"`), which also exercises the rockspec rename end to end since the container reinstalls the plugin from the bind mount on start:

- CRS PL1 regression **2757/2757 (100%)**
- unit **18/18**
- Lua syntax 19/19