### PR TITLE
fix(engine): escape argument names before splicing them into a pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The compiled resolver for `request.arg.value:<name>` was dead code: its guard
+  compared a 19-character slice against the 18-character prefix
+  `request.arg.value:`, which can never be equal, so every ARGS-by-name selector
+  fell back to the engine's table-walk. It now uses the same anchored pattern test
+  as the engine — identical behaviour, one less per-request table scan.
+
 ## [1.5.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Argument names are now escaped before being spliced into the suffix pattern
+  that resolves and removes them. The name went in verbatim, so any Lua pattern
+  metacharacter changed its meaning — and the hyphen is the common case: in
+  `wc-ajax` the `c-` reads as "zero or more c", so a condition on
+  `request.arg.value:wc-ajax` did **not** match the argument it named and **did**
+  match `wcajax`, while a `ctl:ruleRemoveTargetById=…;ARGS:g-recaptcha-response`
+  exclusion removed nothing. Bracketed WordPress names
+  (`data[wp_autosave][excerpt]`) became a character class and never matched, and a
+  dotted JSON path matched any character instead of a literal dot. Application
+  parameter names are not ours to choose, so every exclusion or rule targeting a
+  hyphenated argument was silently inert, or silently pointed at a different
+  argument. Fixed in all five places that build such a pattern: the
+  `request.arg.value:<name>` and `request.query.value:<name>` resolvers in both
+  the engine and the compiled path, and `remove_ctl_target`. Covered by
+  `ka-unittest/variable_resolution.lua` (real resolvers, with decoys for what the
+  unescaped pattern used to match) and
+  `ka-unittest/wordpress_target_exclusion.lua`. CRS regression unchanged
+  (2757/2757).
 - The compiled resolver for `request.arg.value:<name>` was dead code: its guard
   compared a 19-character slice against the 18-character prefix
   `request.arg.value:`, which can never be equal, so every ARGS-by-name selector

--- a/ka-unittest/variable_resolution.lua
+++ b/ka-unittest/variable_resolution.lua
@@ -95,6 +95,19 @@ local engine = {
     __get_values_forwarded_addr = function()
         return { ["request.forwarded_addr"] = kong.client.get_forwarded_ip() }, nil
     end,
+    -- Flattened ARGS as the body parser emits them: source-prefixed keys, one
+    -- per field. The names deliberately carry Lua pattern metacharacters, each
+    -- paired with a decoy whose name is what the unescaped pattern would match.
+    __get_values_request_args = function()
+        return {
+            ["request.query.value:wc-ajax"]                    = "checkout",
+            ["request.query.value:wcajax"]                     = "decoy-hyphen",
+            ["request.body.urlencode.value:data[wp_autosave]"] = "blob",
+            ["request.body.urlencode.value:dataXwp_autosaveY"] = "decoy-bracket",
+            ["request.body.json.value:payer.name.surname"]     = "Rossi",
+            ["request.body.json.value:payerXnameXsurname"]     = "decoy-dot",
+        }, nil
+    end,
 }
 
 local failures = 0
@@ -162,6 +175,45 @@ check("request.forwarded_addr resolves Kong's forwarded client",
 check("remote_addr and forwarded_addr stay distinct",
       resolve("request.remote_addr")["request.remote_addr"]
         ~= resolve("request.forwarded_addr")["request.forwarded_addr"])
+
+-- ---------------------------------------------------------------------------
+print("")
+print("argument selector, names with Lua pattern metacharacters:")
+-- ---------------------------------------------------------------------------
+
+-- The selector name is spliced into a suffix pattern, so it has to be escaped
+-- first. Unescaped, `wc-ajax` reads as "w, zero or more c, ajax": the selector
+-- missed the argument it named AND resolved one it did not
+-- (`?wcajax=` matched `request.arg.value:wc-ajax`). Same class of bug on the
+-- removal side, where a `ctl:...;ARGS:g-recaptcha-response` exclusion removed
+-- nothing. Application parameter names are not ours to choose — wc-ajax,
+-- g-recaptcha-response and data[wp_autosave] are all real — so escaping is the
+-- only fix.
+local function keys_of(t)
+    local out = {}
+    for k in pairs(t or {}) do out[#out + 1] = k end
+    table.sort(out)
+    return table.concat(out, ",")
+end
+
+values = resolve("request.arg.value:wc-ajax")
+check("hyphenated name resolves the argument it names",
+      keys_of(values) == "request.query.value:wc-ajax", keys_of(values))
+
+values = resolve("request.arg.value:wcajax")
+check("...and does not steal the hyphen-free sibling",
+      keys_of(values) == "request.query.value:wcajax", keys_of(values))
+
+values = resolve("request.arg.value:data[wp_autosave]")
+check("bracketed name matches literally, not as a character class",
+      keys_of(values) == "request.body.urlencode.value:data[wp_autosave]", keys_of(values))
+
+values = resolve("request.arg.value:payer.name.surname")
+check("dotted name matches a literal dot, not any character",
+      keys_of(values) == "request.body.json.value:payer.name.surname", keys_of(values))
+
+values = resolve("request.arg.value:nosuchargument")
+check("a name that matches nothing resolves to nothing", keys_of(values) == "", keys_of(values))
 
 -- ---------------------------------------------------------------------------
 print("")

--- a/ka-unittest/wordpress_target_exclusion.lua
+++ b/ka-unittest/wordpress_target_exclusion.lua
@@ -28,6 +28,10 @@ local string_sub  = string.sub
 -- ============================================================
 -- SUT — copy from ka_engine.lua:remove_ctl_target
 -- ============================================================
+local function escape_lua_pattern(s)
+    return (string.gsub(s, "([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1"))
+end
+
 local function remove_ctl_target(values, target, variable)
     if not values or type(target) ~= "string" then return end
     if values[target] ~= nil then values[target] = nil end
@@ -40,8 +44,9 @@ local function remove_ctl_target(values, target, variable)
     local vcolon = string_find(variable, ":", 1, true)
     local var_ns = vcolon and string_sub(variable, 1, vcolon - 1) or variable
     if t_ns ~= var_ns then return end
+    local t_esc = escape_lua_pattern(t_name)
     for k in pairs(values) do
-        if string_find(k, "%." .. t_name .. "$") or string_find(k, ":" .. t_name .. "$") then
+        if string_find(k, "%." .. t_esc .. "$") or string_find(k, ":" .. t_esc .. "$") then
             values[k] = nil
         end
     end
@@ -111,6 +116,33 @@ remove_ctl_target(v, "request.arg.value:pwd", "request.arg.value")
 ok(has(v, "request.body.urlencode.value:password"), "password NOT removed")
 ok(has(v, "request.body.urlencode.value:mypwd"),    "mypwd NOT removed")
 ok(not has(v, "request.body.urlencode.value:pwd"),  "pwd removed")
+
+-- ============================================================
+-- names carrying Lua pattern metacharacters
+--
+-- The target name is spliced into a suffix pattern, so it has to be escaped.
+-- Unescaped, `g-recaptcha-response` reads as "g, zero or more -"… and removed
+-- NOTHING, while a name like `wc-ajax` removed the wrong field (`wcajax`).
+-- Application parameter names are not ours to choose, so escaping is the fix.
+-- ============================================================
+print("- names with pattern metacharacters")
+v = { ["request.query.value:g-recaptcha-response"] = "token",
+      ["request.query.value:grecaptcharesponse"]   = "decoy" }
+remove_ctl_target(v, "request.arg.value:g-recaptcha-response", "request.arg.value")
+ok(not has(v, "request.query.value:g-recaptcha-response"), "hyphenated name removed")
+ok(has(v, "request.query.value:grecaptcharesponse"),       "hyphen-free sibling NOT removed")
+
+v = { ["request.body.urlencode.value:data[wp_autosave]"] = "blob",
+      ["request.body.urlencode.value:dataXwp_autosaveY"] = "decoy" }
+remove_ctl_target(v, "request.arg.value:data[wp_autosave]", "request.arg.value")
+ok(not has(v, "request.body.urlencode.value:data[wp_autosave]"), "bracketed name removed")
+ok(has(v, "request.body.urlencode.value:dataXwp_autosaveY"),     "character-class decoy NOT removed")
+
+v = { ["request.body.json.value:payer.name.surname"] = "Rossi",
+      ["request.body.json.value:payerXnameXsurname"] = "decoy" }
+remove_ctl_target(v, "request.arg.value:payer.name.surname", "request.arg.value")
+ok(not has(v, "request.body.json.value:payer.name.surname"), "dotted name removed")
+ok(has(v, "request.body.json.value:payerXnameXsurname"),     "any-char decoy NOT removed")
 
 -- ============================================================
 -- degenerate inputs don't crash

--- a/kong/plugins/karna/modules/ka_compile.lua
+++ b/kong/plugins/karna/modules/ka_compile.lua
@@ -18,6 +18,14 @@
 
 local _M = {}
 
+-- Escape Lua pattern magic characters in a field NAME before splicing it into a
+-- suffix pattern. Mirrors escape_lua_pattern in ka_engine.lua, where the full
+-- rationale lives: without it a hyphenated argument name (`wc-ajax`) resolves
+-- the wrong argument, because `c-` is a Lua quantifier.
+local function escape_lua_pattern(s)
+    return (string.gsub(s, "([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1"))
+end
+
 -- Stage 1 source template, compiled once at module load time. Each
 -- rule instantiates this chunk by calling _stage1_chunk(rule); the
 -- chunk's vararg becomes the closure's captured upvalue.
@@ -266,6 +274,7 @@ function _M.compile_variable_resolver(variable)
     if string.find(variable, "^request%.arg%.value%:") then
         local arg_name = string.match(variable, "^request%.arg%.value%:(.*)")
         if arg_name == nil then return nil end
+        arg_name = escape_lua_pattern(arg_name)
         local suffix1 = "%." .. arg_name .. "$"
         local suffix2 = ":" .. arg_name .. "$"
         return function(engine, rule)
@@ -315,7 +324,7 @@ function _M.compile_variable_resolver(variable)
         end
     end
     if string.find(variable, "^request%.query%.value%:") then
-        local arg_name = string.match(variable, "^request%.query%.value%:(.*)")
+        local arg_name = escape_lua_pattern(string.match(variable, "^request%.query%.value%:(.*)"))
         local suffix = ":" .. arg_name .. "$"
         return function(engine, rule)
             local qvals = engine.__get_values_request_query_value(false)

--- a/kong/plugins/karna/modules/ka_compile.lua
+++ b/kong/plugins/karna/modules/ka_compile.lua
@@ -258,13 +258,13 @@ function _M.compile_variable_resolver(variable)
 
     -- request.arg.value:<name> — single ARGS entry by name. Suffix
     -- patterns precomputed; the closure only iterates and filters.
-    if string.sub(variable, 1, 19) == "request.arg.value:" then
-        local arg_name = string.sub(variable, 19)
-        -- The leading `:` in the substring boundary: variable is
-        -- "request.arg.value:<name>" (no `:` index 19 because string
-        -- indexes are 1-based — `request.arg.value:` is 18 chars).
-        -- Recompute precisely:
-        arg_name = string.match(variable, "^request%.arg%.value%:(.*)")
+    --
+    -- The guard used to be `string.sub(variable, 1, 19) == "request.arg.value:"`,
+    -- which can never be true: that prefix is 18 characters, so a 19-character
+    -- slice never equals it. The branch was dead and every ARGS-by-name selector
+    -- fell back to the engine's table-walk. Same test as the engine uses now.
+    if string.find(variable, "^request%.arg%.value%:") then
+        local arg_name = string.match(variable, "^request%.arg%.value%:(.*)")
         if arg_name == nil then return nil end
         local suffix1 = "%." .. arg_name .. "$"
         local suffix2 = ":" .. arg_name .. "$"

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -66,6 +66,25 @@ local string_len                        = string.len
 local string_find                       = string.find
 local string_sub                        = string.sub
 
+-- Escape Lua pattern magic characters in a field NAME before it is spliced
+-- into a suffix pattern.
+--
+-- Argument and target names come from rules and from the application's own
+-- parameters, so they routinely contain characters that mean something in a Lua
+-- pattern. A hyphen is the dangerous one: in `wc-ajax` the `c-` is read as
+-- "zero or more c", so the pattern `:wc-ajax$` does NOT match the key
+-- `…:wc-ajax` and DOES match `…:wcajax` — the selector silently resolved the
+-- wrong argument, and a `ctl:ruleRemoveTargetById=…;ARGS:g-recaptcha-response`
+-- exclusion silently removed nothing. `[` `]` did the same for the
+-- `data[wp_autosave][excerpt]` style of WordPress parameter, and `.` matched any
+-- character instead of a literal dot (harmless but wider than declared).
+--
+-- Every place that builds `":" .. name .. "$"` must escape first. Mirrored in
+-- ka_compile.lua for the compiled resolvers.
+local function escape_lua_pattern(s)
+    return (string_gsub(s, "([%^%$%(%)%%%.%[%]%*%+%-%?])", "%%%1"))
+end
+
 -- Remove a ctl exclusion target from a resolved `values` map.
 --
 -- Historically this was an exact key lookup (`values[target] = nil`),
@@ -110,8 +129,9 @@ local function remove_ctl_target(values, target, variable)
 
     -- suffix match, identical to the rule-side ARGS expansion, so exclusion
     -- and rule look at EXACTLY the same keys (no bypass, no over-removal).
+    local t_esc = escape_lua_pattern(t_name)
     for k in pairs(values) do
-        if string_find(k, "%." .. t_name .. "$") or string_find(k, ":" .. t_name .. "$") then
+        if string_find(k, "%." .. t_esc .. "$") or string_find(k, ":" .. t_esc .. "$") then
             values[k] = nil
         end
     end
@@ -2667,7 +2687,7 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                     end
                     err = all_err
                 elseif string_find(variable, "^request%.arg%.value%:") then
-                    local arg_name = string_match(variable, "^request%.arg%.value%:(.*)")
+                    local arg_name = escape_lua_pattern(string_match(variable, "^request%.arg%.value%:(.*)"))
                     local all_values, all_err = self:__get_values_request_args(false, rule.rule_control)
                     if all_values then
                         values = {}
@@ -2713,7 +2733,7 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                         if next(values) == nil then values = nil end
                     end
                 elseif string_find(variable, "^request%.query%.value%:") then
-                    local arg_name = string_match(variable, "^request%.query%.value%:(.*)")
+                    local arg_name = escape_lua_pattern(string_match(variable, "^request%.query%.value%:(.*)"))
                     local qvals = _M.__get_values_request_query_value(false)
                     if qvals then
                         values = {}


### PR DESCRIPTION
Two fixes in the same place, one commit each.

## 1. Argument names went into a Lua pattern unescaped

An argument name is spliced into a suffix pattern (`":" .. name .. "$"`) to resolve it and to remove it. It went in verbatim, so any Lua pattern metacharacter changed the meaning of the match — and the hyphen fails in **both** directions at once. Measured against a live Kong:

```
condition request.arg.value:wc-ajax  on ?wc-ajax=checkout        no match
condition request.arg.value:wc-ajax  on ?wcajax=checkout         MATCHED (wrong argument)
remove target g-recaptcha-response   on ?g-recaptcha-response=   not removed
remove target grecaptcharesponse     on ?grecaptcharesponse=     removed
```

In `wc-ajax` the `c-` reads as "zero or more c", so `:wc-ajax$` misses the key it names and hits `:wcajax` instead. Bracketed WordPress names (`data[wp_autosave][excerpt]`) became a character class and never matched — that case was already known, but written off as "bracketed arg names are a no-op" instead of recognised as this bug. A dotted JSON path (`payer.name.surname`) matched any character where a literal dot was declared.

Application parameter names are not ours to choose: `wc-ajax`, `g-recaptcha-response` and `data[...]` are all real. So every rule condition and every `ctl:ruleRemoveTargetById=…;ARGS:<name>` exclusion targeting a hyphenated argument was silently inert, or silently pointed at a different argument. That is the worst failure mode for a WAF: an exclusion that removes nothing shows up as a false positive nobody can explain, and one that removes the wrong field is a hole.

Escaped in all five places that build such a pattern — the `request.arg.value:<name>` and `request.query.value:<name>` resolvers in the engine and in the compiled path, plus `remove_ctl_target`.

## 2. The compiled `request.arg.value:<name>` resolver was dead code

Its guard compared a 19-character slice against the 18-character prefix `request.arg.value:`, which can never be equal. The branch had never executed and every ARGS-by-name selector fell back to the engine's table-walk instead of the precompiled closure. Same anchored test as the engine now; behaviour identical, one fewer per-request table scan. Found by a unit test that resolved through `ka_compile` and got nothing back.

## Verification

- `ka-unittest/variable_resolution.lua` gains a section on the real resolvers, each case paired with the decoy key the unescaped pattern used to match (`wcajax`, `dataXwp_autosaveY`, `payerXnameXsurname`).
- `ka-unittest/wordpress_target_exclusion.lua` gains the same three cases on the removal side, and its inline replica is back in sync with the engine (the file's own contract).
- Full unit suite green by exit code.
- CRS regression 2757/2757. Against a private exclusion pack it stays at 2725/2757, unchanged from before the fix — the escaping does not over-remove. On that pack the exclusions for `g-recaptcha-response`, `wp-submit` and `nav-menu-data` now apply, where before they did nothing, and same-but-different names (`grecaptcharesponse`, `wpsubmit`) are still blocked.

No version bump; both entries are under `## [Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)