### PR TITLE
release: v1.5.1 — the audit log can no longer be silenced by the client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
         run: lua ka-unittest/rule_control_runtime.lua
       - name: log_only action (non-terminal match reaches the audit log)
         run: lua ka-unittest/log_only_action.lua
+      - name: Audit log UTF-8 sanitisation (attacker cannot make its record undecodable)
+        run: lua ka-unittest/auditlog_utf8_sanitize.lua
 
   leak-audit:
     name: Anti-leak audit (internal naming)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-08-05
+
 ### Security
 
 - An audit log record can no longer be made undecodable by the client. Every
@@ -740,7 +742,8 @@ Core Rule Set. It needs no other plugin to work.
   inspected by default (set it to `true` to bypass trusted internal ranges).
 - The PL1 OWASP CRS regression suite passes at 100%.
 
-[Unreleased]: https://github.com/sicuranext/karna/compare/v1.1.5...HEAD
+[Unreleased]: https://github.com/sicuranext/karna/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/sicuranext/karna/compare/v1.5.0...v1.5.1
 [1.1.5]: https://github.com/sicuranext/karna/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/sicuranext/karna/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/sicuranext/karna/compare/v1.1.2...v1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,45 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- An audit log record can no longer be made undecodable by the client. Every
+  record is now validated as UTF-8 immediately before it is written, and any byte
+  that is not part of a well-formed sequence is rewritten as the literal text
+  `\xNN`. `cjson` does not validate UTF-8 — it copies bytes `>= 0x80` through
+  untouched and reports no error — so a single bad byte produced a JSON Lines
+  record that every UTF-8-strict consumer (Filebeat, Fluent Bit, Vector,
+  Elasticsearch, a plain `json.loads`, `jq`) silently dropped. The bytes in a
+  record are attacker-controlled, which made this an on-demand audit-trail
+  suppression primitive: `?p=<script>alert(1)</script>%c3%28` was blocked with a
+  403 whose record could not be read, and a request carrying
+  `X-Evil: abc\xc3(def` corrupted its own record with **no rule match at all**.
+  The same corruption occurred without any client intent, because `matched_value`
+  is clipped with a byte-based `string.sub(v, 1, 100)`: a multibyte codepoint
+  straddling byte 100 left an orphan lead byte, so any request whose payload
+  carried an emoji, an accent, a typographic quote or non-Latin text near the cut
+  fell out of the log pipeline. Escaping rather than dropping keeps the record
+  forensically honest — the reader sees which byte arrived, and a clipped value
+  now ends in a visible `\xc3` instead of losing its tail silently. The check
+  runs in `ka_utils.write_auditlog`, inside the `ngx.timer.at()` callback: it is
+  the single choke point every record passes through, it also covers the fields
+  no truncation site touches (request and response headers, the URI, gate
+  `logdata`, `external_matches`), and it costs nothing on the request path.
+  Pure-ASCII records — the vast majority of traffic — leave after one C-level
+  scan with no allocation. Covered by `ka-unittest/auditlog_utf8_sanitize.lua`
+  (overlong forms, UTF-16 surrogate halves, values beyond U+10FFFF, stray
+  continuation bytes, every clip offset inside a 4-byte codepoint, all 256 byte
+  values), asserted against an independent UTF-8 validator. CRS regression
+  unchanged (2757/2757).
+
 ### Fixed
 
+- Removed the dead `gsub("[\r\n]", "")` from the audit log writer. It claimed to
+  strip embedded CR/LF so the record stays one physical line, but it ran on the
+  already-encoded JSON, where `cjson` has escaped every control character (keys
+  included) — so it never matched anything. Code that looks like a safety net and
+  is not one is worse than no net at all; the real invariant is now enforced by
+  the UTF-8 validation above, at the same choke point.
 - Argument names are now escaped before being spliced into the suffix pattern
   that resolves and removes them. The name went in verbatim, so any Lua pattern
   metacharacter changed its meaning — and the hyphen is the common case: in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,11 +114,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.5.0-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.5.1-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.5.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.5.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.5.0-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.5.0-0.rockspec:ro
+      - ../kong-plugin-karna-1.5.1-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.5.1-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
       # Pairs with KARNA_GLOBAL_RULES_PATH above (both commented out by default).
       # - ./global-rules.d:/etc/kong/karna/global-rules.d:ro

--- a/ka-unittest/auditlog_utf8_sanitize.lua
+++ b/ka-unittest/auditlog_utf8_sanitize.lua
@@ -1,0 +1,215 @@
+-- ka-unittest/auditlog_utf8_sanitize.lua
+--
+-- Guards ka_utils.sanitize_utf8 — the last thing that touches an audit record
+-- before it hits disk. Its job: no line leaves Karna unless it is valid UTF-8.
+--
+-- Why this is a security guard and not log cosmetics. cjson does NOT validate
+-- UTF-8; it copies bytes >= 0x80 through untouched and reports no error. The
+-- bytes in an audit record are attacker-controlled (matched values, request
+-- headers, the URI), so before this guard existed a client could hand Karna a
+-- byte that made its own record undecodable, and every UTF-8-strict consumer
+-- (Filebeat / Fluent Bit / Vector / Elasticsearch / json.loads) dropped the
+-- line. Two confirmed shapes, both with no rule authoring involved:
+--   * ?p=<script>alert(1)</script>%c3%28  -> blocked 403, record unreadable
+--   * X-Evil: abc\xc3(def                 -> benign request, no rule match,
+--                                           record unreadable anyway
+-- That is an on-demand audit-trail suppression primitive, so the invariant is
+-- pinned here rather than left to review.
+--
+-- Second shape covered: Karna cutting a character in half itself. matched_value
+-- is clipped with a byte-based string.sub(v, 1, 100) in ~30 places in
+-- ka_engine, so a multibyte codepoint straddling byte 100 leaves an orphan lead
+-- byte. Escaping rather than dropping keeps the record honest — the reader sees
+-- which byte arrived.
+--
+-- The test asserts the output property with an INDEPENDENT UTF-8 validator
+-- written below, not by reusing the implementation, so a bug in the validation
+-- logic cannot pass itself.
+--
+-- Run from repo root:
+--   lua    ka-unittest/auditlog_utf8_sanitize.lua
+--   luajit ka-unittest/auditlog_utf8_sanitize.lua
+
+package.path = "./kong/plugins/karna/modules/?.lua;" .. package.path
+
+-- ngx / kong stubs: ka_utils captures kong.request.* etc. at module load.
+package.preload["kong.plugins.karna.version"] = function()
+    return { version = "test", commit = "test", built_at = "test" }
+end
+_G.ngx = {
+    re = { match = function() return nil end },
+    var = setmetatable({}, { __index = function() return nil end }),
+    log = function() end,
+}
+_G.kong = {
+    log = { err = function() end, warn = function() end, debug = function() end },
+    request = {
+        get_header = function() return nil end, get_headers = function() return {} end,
+        get_path_with_query = function() return "/" end, get_method = function() return "GET" end,
+        get_http_version = function() return 1.1 end,
+    },
+    service = { response = { get_headers = function() return {} end, get_status = function() return 200 end } },
+    response = { get_status = function() return 200 end },
+}
+
+local utils = dofile("./kong/plugins/karna/modules/ka_utils.lua")
+local sanitize = utils.sanitize_utf8
+
+local failures = 0
+local function check(name, cond, detail)
+    if cond then print("  ok   - " .. name)
+    else failures = failures + 1; print("  FAIL - " .. name .. (detail and ("  (" .. detail .. ")") or "")) end
+end
+
+-- Independent validator. Deliberately written from the UTF-8 table rather than
+-- copied from the implementation: it is the oracle, not a mirror.
+local function is_valid_utf8(s)
+    local i, len = 1, #s
+    while i <= len do
+        local c = s:byte(i)
+        local n
+        if     c <= 0x7F then n = 1
+        elseif c >= 0xC2 and c <= 0xDF then n = 2
+        elseif c >= 0xE0 and c <= 0xEF then n = 3
+        elseif c >= 0xF0 and c <= 0xF4 then n = 4
+        else return false, i end
+        if i + n - 1 > len then return false, i end
+        for k = 1, n - 1 do
+            local cc = s:byte(i + k)
+            if cc < 0x80 or cc > 0xBF then return false, i end
+        end
+        if n > 1 then
+            local c1 = s:byte(i + 1)
+            if (c == 0xE0 and c1 < 0xA0)      -- overlong 3-byte
+            or (c == 0xED and c1 > 0x9F)      -- UTF-16 surrogate half
+            or (c == 0xF0 and c1 < 0x90)      -- overlong 4-byte
+            or (c == 0xF4 and c1 > 0x8F) then -- beyond U+10FFFF
+                return false, i
+            end
+        end
+        i = i + n
+    end
+    return true
+end
+
+local function hex(s)
+    return (s:gsub(".", function(c) return string.format("%02x ", c:byte()) end))
+end
+
+-- ---------------------------------------------------------------------------
+print("valid input passes through untouched:")
+-- ---------------------------------------------------------------------------
+
+-- The fast path matters: pure-ASCII records are the vast majority of traffic
+-- and must not be rebuilt.
+local ascii = '{"value":"<script>alert(1)</script>","on":"request.arg.value:p"}'
+check("pure ASCII returns the identical string", sanitize(ascii) == ascii)
+check("empty string survives", sanitize("") == "")
+
+local valid_cases = {
+    ["2-byte (e-acute)"]        = "caf\xc3\xa9",
+    ["3-byte (almost-equal)"]   = "circa \xe2\x89\x88 13%",
+    ["4-byte (party popper)"]   = "done \xf0\x9f\x8e\x89",
+    ["Cyrillic"]                = "\xd0\xbf\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82",
+    ["CJK"]                     = "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e",
+    ["U+10FFFF (top of range)"] = "\xf4\x8f\xbf\xbf",
+    ["U+0080 (low 2-byte)"]     = "\xc2\x80",
+}
+for name, s in pairs(valid_cases) do
+    check("valid UTF-8 is not rewritten: " .. name, sanitize(s) == s, hex(sanitize(s)))
+end
+
+-- ---------------------------------------------------------------------------
+print("")
+print("bytes Karna produces itself (truncation at byte 100):")
+-- ---------------------------------------------------------------------------
+
+-- Exactly what string.sub(v, 1, 100) does when a codepoint straddles the cut.
+check("orphan 2-byte lead becomes text",
+      sanitize("A\xc3") == "A\\\\xc3", hex(sanitize("A\xc3")))
+check("orphan 3-byte lead + 1 continuation becomes text",
+      sanitize("A\xe2\x89") == "A\\\\xe2\\\\x89", hex(sanitize("A\xe2\x89")))
+check("orphan 4-byte lead becomes text",
+      sanitize("A\xf0\x9f\x8e") == "A\\\\xf0\\\\x9f\\\\x8e", hex(sanitize("A\xf0\x9f\x8e")))
+
+for cut = 1, 4 do
+    -- Take a valid multibyte string and clip it at every offset: whatever
+    -- comes out must be valid UTF-8.
+    local s = ("A"):rep(3) .. "\xf0\x9f\x8e\x89" .. "tail"
+    local clipped = s:sub(1, 3 + cut)
+    local out = sanitize(clipped)
+    check("clip inside a 4-byte codepoint at +" .. cut .. " yields valid UTF-8",
+          is_valid_utf8(out), hex(out))
+end
+
+-- ---------------------------------------------------------------------------
+print("")
+print("bytes the client supplies (no truncation involved):")
+-- ---------------------------------------------------------------------------
+
+local hostile = {
+    ["stray continuation 0x80"]      = "abc\x80def",
+    ["stray continuation 0xbf"]      = "abc\xbfdef",
+    ["overlong 2-byte lead 0xc0"]    = "abc\xc0\xafdef",
+    ["overlong 2-byte lead 0xc1"]    = "abc\xc1\xbfdef",
+    ["overlong 3-byte (/)"]          = "abc\xe0\x80\xafdef",
+    ["overlong 4-byte"]              = "abc\xf0\x80\x80\xafdef",
+    ["UTF-16 surrogate half"]        = "abc\xed\xa0\x80def",
+    ["beyond U+10FFFF (0xf4 0x90)"]  = "abc\xf4\x90\x80\x80def",
+    ["invalid lead 0xf5"]            = "abc\xf5\x80\x80\x80def",
+    ["invalid lead 0xff"]            = "abc\xffdef",
+    ["truncated sequence mid-string"]= "abc\xe2(def",
+    ["the %c3%28 evasion payload"]   = "<script>alert(1)</script>\xc3(",
+    ["the X-Evil header payload"]    = "abc\xc3(def",
+    ["all 256 byte values"]          = (function()
+        local t = {}
+        for b = 0, 255 do t[#t + 1] = string.char(b) end
+        return table.concat(t)
+    end)(),
+}
+for name, s in pairs(hostile) do
+    local out = sanitize(s)
+    local valid, at = is_valid_utf8(out)
+    check("hostile input yields valid UTF-8: " .. name, valid,
+          valid and nil or ("first bad byte at " .. tostring(at) .. " -> " .. hex(out)))
+end
+
+check("a bad byte in the middle keeps the surrounding text",
+      sanitize("abc\xffdef") == "abc\\\\xffdef", hex(sanitize("abc\xffdef")))
+check("every byte of an illegal sequence is escaped, none silently dropped",
+      sanitize("\xe0\x80\xaf") == "\\\\xe0\\\\x80\\\\xaf", hex(sanitize("\xe0\x80\xaf")))
+check("valid and invalid interleaved keep their order",
+      sanitize("\xc3\xa9\xff\xc3\xa8") == "\xc3\xa9\\\\xff\xc3\xa8",
+      hex(sanitize("\xc3\xa9\xff\xc3\xa8")))
+
+-- ---------------------------------------------------------------------------
+print("")
+print("JSON safety of the substitution:")
+-- ---------------------------------------------------------------------------
+
+-- The replacement is inserted into an ALREADY-ENCODED JSON line, so it must be
+-- ASCII, must not introduce a raw newline, and must carry two backslashes on
+-- the wire so that a decoder yields the 4-character text \xc3 (one backslash).
+-- An odd number of backslashes would turn an encoding bug into a JSON syntax
+-- error, which is strictly worse: the whole line would fail to parse.
+local out = sanitize('{"value":"AAA\xc3","on":"request.header.value:x-evil"}')
+check("sanitized line is valid UTF-8", is_valid_utf8(out), hex(out))
+check("substitution is pure ASCII", not out:find("[\128-\255]"))
+check("substitution introduces no raw newline", not out:find("[\r\n]"))
+check("substitution carries an even number of backslashes",
+      select(2, out:gsub("\\", "")) % 2 == 0)
+check("JSON structure characters are untouched",
+      out == '{"value":"AAA\\\\xc3","on":"request.header.value:x-evil"}', out)
+
+-- The escape text must not itself be re-escapable into something else: NN is
+-- always two lowercase hex digits, so \xc3 can never read as \xc (a broken
+-- \uXXXX-style truncation of our own making).
+for _, b in ipairs({ 0x80, 0xc0, 0xf5, 0xff }) do
+    local o = sanitize(string.char(b))
+    check(string.format("byte 0x%02x escapes to exactly 5 ASCII chars", b),
+          #o == 5 and o == string.format("\\\\x%02x", b), hex(o))
+end
+
+print("")
+if failures == 0 then print("ALL PASS"); os.exit(0)
+else print(tostring(failures) .. " FAILURE(S)"); os.exit(1) end

--- a/kong-plugin-karna-1.5.1-0.rockspec
+++ b/kong-plugin-karna-1.5.1-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.5.0-0"
+version = "1.5.1-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.5.0"
+  tag = "v1.5.1"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.5.0",
+  VERSION = "1.5.1",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/modules/ka_utils.lua
+++ b/kong/plugins/karna/modules/ka_utils.lua
@@ -12,6 +12,11 @@ local request_get_method            = kong.request.get_method
 local request_get_http_version      = kong.request.get_http_version
 
 local string_match                  = string.match
+local string_byte                   = string.byte
+local string_sub                    = string.sub
+local string_find                   = string.find
+local string_format                 = string.format
+local table_concat                  = table.concat
 
 local ka_version            = require "kong.plugins.karna.version"
 
@@ -788,6 +793,125 @@ _M.get_auditlog_v2 = function(self, matched_rules, plugin_conf)
     return json_log
 end
 
+-- Rewrite every byte that is not part of a well-formed UTF-8 sequence as the
+-- literal text \xNN, so an emitted record is always valid UTF-8 and therefore
+-- ingestable by every UTF-8-strict log consumer (Filebeat / Fluent Bit /
+-- Vector / Elasticsearch / a plain `json.loads`). cjson does NOT validate
+-- UTF-8: it copies bytes >= 0x80 through untouched and reports no error, so
+-- without this guard a single bad byte silently produces a line that the
+-- collector drops — i.e. the request looks like it was never logged.
+--
+-- This is a security control, not log cosmetics: the bad byte is
+-- attacker-controlled. `?p=<script>alert(1)</script>%c3%28` is blocked with a
+-- 403 whose audit record is then unreadable, and a benign request carrying
+-- `X-Evil: abc\xc3(def` corrupts its own record with no rule match at all.
+-- Left unfixed, that is an on-demand audit-trail suppression primitive.
+--
+-- Why it runs here, on the already-encoded line, rather than at the ~30
+-- `string.sub(value, 1, 100)` truncation sites in ka_engine:
+--   * those sites run in the access phase, on the request path; this runs in
+--     the ngx.timer.at() callback, after the response has left;
+--   * they only cover matched values. Invalid bytes also reach the record via
+--     request/response headers, the URI, gate logdata and external_matches,
+--     none of which pass through a truncation site.
+-- Post-encode is safe because cjson escapes every control character (keys
+-- included), so the only non-ASCII left sits inside JSON string literals,
+-- where inserting ASCII cannot break the syntax.
+--
+-- Escaping rather than dropping keeps the record forensically honest: the
+-- reader sees exactly which byte arrived. A value cut mid-character by the
+-- 100-byte truncation therefore ends in a visible \xc3 instead of silently
+-- losing its tail.
+_M.sanitize_utf8 = function(s)
+    -- Pure-ASCII records — the vast majority of traffic — leave after a
+    -- single C-level scan, with no Lua loop and no allocation.
+    if not string_find(s, "[\128-\255]") then
+        return s
+    end
+
+    local len = #s
+    local out          -- built lazily: only an actually invalid byte costs us
+    local n   = 0
+    local run = 1      -- first byte of the pending verbatim run
+    local i   = 1
+
+    while i <= len do
+        local c = string_byte(s, i)
+        local seq_len = 0
+
+        if c < 0x80 then
+            seq_len = 1
+        elseif c >= 0xC2 and c <= 0xDF then
+            seq_len = 2
+        elseif c >= 0xE0 and c <= 0xEF then
+            seq_len = 3
+        elseif c >= 0xF0 and c <= 0xF4 then
+            seq_len = 4
+        end
+        -- 0x80-0xBF (stray continuation), 0xC0-0xC1 (overlong two-byte forms)
+        -- and 0xF5-0xFF (beyond U+10FFFF) leave seq_len at 0 == invalid lead.
+
+        local ok = seq_len > 0
+
+        if ok and seq_len > 1 then
+            if i + seq_len - 1 > len then
+                ok = false                      -- sequence runs off the end
+            else
+                for k = 1, seq_len - 1 do
+                    local cc = string_byte(s, i + k)
+                    if cc < 0x80 or cc > 0xBF then
+                        ok = false
+                        break
+                    end
+                end
+
+                if ok then
+                    -- Reject the encodings that are structurally well-formed
+                    -- but still illegal: overlong forms (a decoder that
+                    -- accepts them can be tricked past a byte-level filter),
+                    -- UTF-16 surrogate halves, and anything above U+10FFFF.
+                    local c1 = string_byte(s, i + 1)
+                    if c == 0xE0 and c1 < 0xA0 then
+                        ok = false
+                    elseif c == 0xED and c1 > 0x9F then
+                        ok = false
+                    elseif c == 0xF0 and c1 < 0x90 then
+                        ok = false
+                    elseif c == 0xF4 and c1 > 0x8F then
+                        ok = false
+                    end
+                end
+            end
+        end
+
+        if ok then
+            i = i + seq_len
+        else
+            if not out then out = {} end
+            if i > run then
+                n = n + 1
+                out[n] = string_sub(s, run, i - 1)
+            end
+            -- Two backslashes on the wire so the decoded value reads \xc3.
+            n = n + 1
+            out[n] = string_format("\\\\x%02x", c)
+            i = i + 1
+            run = i
+        end
+    end
+
+    if not out then
+        return s        -- every high byte was well-formed UTF-8
+    end
+
+    if run <= len then
+        n = n + 1
+        out[n] = string_sub(s, run, len)
+    end
+
+    return table_concat(out, "", 1, n)
+end
+
 _M.write_auditlog = function(premature, json_log, auditlog_path, timestamp, worker_id)
     if premature then return end
 
@@ -804,12 +928,16 @@ _M.write_auditlog = function(premature, json_log, auditlog_path, timestamp, work
     kong.log.debug("Karna: writing audit log to file: ", filename)
     local file = io.open(filename, "a")
     if file then
-        -- Strip any embedded CR/LF so the record is a single physical line,
-        -- then terminate it with one trailing newline. This is the JSON Lines
-        -- (NDJSON) convention log collectors expect — Filebeat / Fluent Bit /
-        -- Vector / Promtail split on newline and parse one object per line.
-        local json_log_no_newlines = cjson.encode(json_log):gsub("[\r\n]","")
-        file:write(json_log_no_newlines, "\n")
+        -- One record per physical line, terminated by a single newline: the
+        -- JSON Lines (NDJSON) convention log collectors expect — Filebeat /
+        -- Fluent Bit / Vector / Promtail split on newline and parse one object
+        -- per line. cjson already escapes every CR/LF (and every other control
+        -- character, keys included), so the encoded record can never contain a
+        -- raw newline; what it CAN contain is a byte that is not valid UTF-8,
+        -- which sanitize_utf8 rewrites as text. This is the single choke point
+        -- for both invariants: nothing reaches disk without passing here.
+        local line = _M.sanitize_utf8(cjson.encode(json_log))
+        file:write(line, "\n")
         file:close()
     else
         kong.log.err("Karna: failed to write audit log to file: ", filename)

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.5.0",
+  version      = "1.5.1",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.5.0",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.5.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
## The bug

A client could make its own audit record undecodable, and therefore invisible to any log pipeline.

`cjson` does not validate UTF-8. It copies bytes `>= 0x80` through untouched and reports no error, so one bad byte produced a JSON Lines record that every UTF-8-strict consumer (Filebeat, Fluent Bit, Vector, Elasticsearch, a plain `json.loads`, `jq`) silently dropped. The line was on disk; nothing downstream could read it.

The bytes in an audit record are attacker-controlled, which turned this into an audit-trail suppression primitive available on demand. Both of these were reproduced on the dev stack:

```
?p=<script>alert(1)</script>%c3%28   ->  blocked 403, record unreadable
X-Evil: abc\xc3(def                  ->  benign request, no rule match,
                                         record unreadable anyway
```

The second one is the sharper of the two: no rule authoring, no truncation, no match. A benign request with one bad byte in an arbitrary header corrupts its own record.

The same corruption also happened with no client intent at all. `matched_value` is clipped with a byte-based `string.sub(v, 1, 100)` in ~30 places, so a multibyte codepoint straddling byte 100 left an orphan lead byte. Any payload carrying an emoji, an accent, a typographic quote or non-Latin text near the cut fell out of the log pipeline. That is how this was found: a production `PUT` to a Ghost admin API with an emoji-heavy 75 KB body appeared to emit no log.

## The fix

`ka_utils.sanitize_utf8` rewrites every byte that is not part of a well-formed UTF-8 sequence as the literal text `\xNN`. It also rejects the sequences that are structurally well-formed but still illegal: overlong forms, UTF-16 surrogate halves, and anything above U+10FFFF.

Escaping rather than dropping keeps the record forensically honest. The reader sees which byte arrived, and a value clipped mid-character ends in a visible `\xc3` instead of losing its tail silently.

It runs in `write_auditlog`, inside the `ngx.timer.at()` callback, for three reasons:

- it is the single choke point every record passes through, so no future call site can bypass it;
- it covers the fields no truncation site touches — request and response headers, the URI, gate `logdata`, `external_matches`;
- it costs nothing on the request path. Pure-ASCII records, the vast majority of traffic, leave after one C-level scan with no allocation.

Nothing in `ka_engine` changes. The alternative considered was making the 30 truncation sites UTF-8-aware, which would have been a diff across the hottest module, on the request path, and would still have missed the header case entirely.

Also removes the dead `gsub("[\r\n]", "")` from the writer. It ran on the already-encoded JSON, where `cjson` has escaped every control character including in keys, so it never matched anything. Code that looks like a safety net and is not one is worse than no net.

## Verification

- `ka-unittest/auditlog_utf8_sanitize.lua`, added to CI: overlong forms, surrogate halves, values beyond U+10FFFF, stray continuation bytes, every clip offset inside a 4-byte codepoint, all 256 byte values. The output property is asserted against an independent UTF-8 validator written in the test rather than a mirror of the implementation, so a bug in the validation logic cannot pass itself.
- End to end on the dev stack, replaying every PoC: 22 records, 0 undecodable. Before the fix, 5 of 18 multibyte variants produced a corrupt line.
- CRS PL1 regression 2757/2757 (100%).
- Unit suite 16/16 under LuaJIT.

## Release

Also bumps to v1.5.1 across the places that must move together, and closes the `[Unreleased]` block. The release picks up the two fixes already on `main` unreleased (unescaped argument names in patterns, the dead `request.arg.value:<name>` compiled resolver) plus this one.

No configuration change is needed and no existing rule behaves differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)