### PR TITLE
fix(engine): !isSet now fires on an absent variable

### DIFF
--- a/.claude/skills/karna/reference/rules.md
+++ b/.claude/skills/karna/reference/rules.md
@@ -73,6 +73,12 @@ Not implemented (rules skipped with WARN at parse): `@ipMatchFromFile`, `@verify
 Canonical: `"negated": true` (separate boolean, not a `!` prefix). Legacy `"op": "!rx"` still accepted on input; prefer `negated`.
 A negated condition fires when the positive fails AND the value is present. Exception: `isSet` + `negated:true` is how you spell "variable absent" and fires on a missing variable.
 
+`isSet` + `negated:true` specifics:
+- Does NOT fire on: a target removed by a `ctl:ruleRemoveTargetById`/`ByTag` exclusion (excluded is not missing); an unreadable Redis key; a Redis read with `redis_inspect_enabled` off. For the Redis cases the condition matches only under `redis_on_error: fail_closed`, whichever way the rule is written, so an allowlist rule does not turn a Redis outage into a total outage.
+- DOES fire on: a variable name no resolver recognises (typos are not validated, so the rule blocks every request), and a `response.*` variable in an `access`-phase rule. Both are visible on the first request after deploy.
+- Refused at load on a rule that also carries `rule_control`: such a rule applies its `ctl:*` side effects when it matches, and keyed on absence it fires on ordinary traffic, disabling detection for every request. Key the exclusion on something the request carries.
+- Usable as one link of a chain; several variables in one condition mean "at least one absent".
+
 ## Transformations (in `transform`, applied in order; no implicit transforms)
 `lowercase`, `urlDecodeUni`(=`urlDecode`), `hexSequenceDecode`, `htmlEntityDecode`, `jsDecode`, `cssDecode`, `escapeSeqDecode`, `base64Decode`(=`base64decode`), `removeNulls`, `removeWhitespace`, `compressWhitespace`, `replaceComments`, `removeCommentsChar`, `normalisePath`(=`normalizePath`), `normalizePathWin`, `cmdLine`, `utf8toUnicode`, `length` (→ number), `sha1`, `hexEncode`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: lua ka-unittest/default_block_response.lua
       - name: Op negation normalization (canonical vs legacy)
         run: lua ka-unittest/op_negation_normalization.lua
+      - name: Negated isSet absence (ctl vs absent, Redis three states, load-time refusal)
+        run: lua ka-unittest/negated_isset_absence.lua
       - name: JSON embedded in urlencoded values (flatten regression guard)
         run: lua ka-unittest/json_in_urlencoded.lua
       - name: Redis inspection read helper (whitelist + connection behavior)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- `isSet` with `negated: true` — the documented way to spell "this variable is
+  absent" — now actually fires on a missing variable. It never could: the
+  rule-control removal block collapses an emptied values table to `nil`, so by
+  the time the operator was dispatched `values` truthy always meant "at least one
+  value", and the branch that handled absence sat behind `loop_counter == 0`,
+  which that collapse had already made unreachable. The operator failed silently
+  and in the unsafe direction: a rule that reads as an access control ("deny
+  unless this API key header is present") matched nothing and allowed everything,
+  while looking armed in the config. The Redis allowlist form documented in
+  `docs/rules.html` (`negated: true` on a `redis.<key>` variable, presented as the
+  canonical ban / ACL-TTL check) was dead for the same reason. A rule of that shape
+  that was inert before will start enforcing after this upgrade.
+  - Absence is now distinguished from three states that are not absence. A target
+    deleted by a `ctl:ruleRemoveTargetById` / `ruleRemoveTargetByTag` exclusion
+    keeps skipping the condition, as it does for every other operator — the flag
+    is captured before the removal block, not after. A `response.*` variable read
+    in the access phase, and a variable name no resolver claims, both read as
+    absent: Karna does not validate variable names anywhere and does not start
+    here, so a typo makes the condition always true and blocks every request,
+    which is visible on the first request after deploy.
+  - Redis is now a third state, "unknown", rather than being folded into
+    present/absent. Mapping an unreadable Redis onto presence was safe while only
+    the positive `isSet` existed (a ban check with `redis_on_error = fail_closed`
+    pretends the ban is there and denies), but it inverts under negation: an
+    allowlist rule would have denied every request on `skip` — the default —
+    turning a Redis outage into a total outage, and allowed every request on
+    `fail_closed`, the opposite of both settings. `redis_on_error` is now honoured
+    in terms of the rule's decision rather than the key's presence, and
+    `redis_inspect_enabled = false` counts as unknown too, so switching the
+    feature off no longer denies everything.
+  - A rule that carries `rule_control` **and** a negated `isSet` condition is now
+    refused at load, with an error naming the rule id. A matching rule applies its
+    `ctl:*` side effects, so it can switch detection rules off for the request;
+    keyed on absence its trigger is the default state of ordinary traffic, meaning
+    one such rule silently disables the WAF for everything. Every other way of
+    writing an exclusion has to name something the request actually carries. Safe
+    for the shipped rule packs: SecLang never emits a negated `isSet`, so CRS,
+    `custom_secrules` and the CRS exclusion-plugin files cannot produce this
+    shape — only hand-written JSON in `rules_request` or a global rules pack can.
+  - Fixed along the way: the absence branch used to jump straight to the end of
+    the rule after counting its condition, so a chained rule with a negated
+    `isSet` link could never reach `matched_conditions == #conditions`. It now
+    moves on to the next condition, and several variables in one condition read as
+    "at least one absent", matching the per-condition counting the positive path
+    uses.
+  - Covered by `ka-unittest/negated_isset_absence.lua` (recognition of both input
+    shapes, absence vs values present, the non-table-value guard, the Redis
+    three-state matrix including an assertion that the old inverted mapping is
+    gone, and the load-time refusal) and by
+    `ka-integration-tests/001_negated_isset_bypass.sh`, an adversarial suite of 39
+    cases run against a live Kong: header-name casing and duplication, token
+    comparison games, paths that skip the rule loop, the `rule_control`
+    activation vector, ModSec parity for every other negated operator on an absent
+    variable, the Redis outage matrix, and the `count:` workaround's limits. CRS
+    regression 2757/2757 (100%), unchanged.
+
 ## [1.5.1] - 2026-08-05
 
 ### Security

--- a/docs/rules.html
+++ b/docs/rules.html
@@ -221,6 +221,9 @@
 }</pre></div>
       </div>
       <p>Semantics: a negated condition fires when the positive match fails <strong>and</strong> the value is present. A missing variable does not satisfy a negated condition. The one exception is <code>isSet</code> with <code>negated: true</code>, which is the way to spell "variable is absent" and so fires on a missing variable.</p>
+      <p>Three things count as "not absent", so a negated <code>isSet</code> does <strong>not</strong> fire on them: a target removed by a <code>ctl:ruleRemoveTargetById</code> / <code>ruleRemoveTargetByTag</code> exclusion (an excluded target is not a missing variable), an unreadable Redis key, and a Redis read with <code>redis_inspect_enabled</code> off. See <a href="#redis">Redis variables</a> for how <code>redis_on_error</code> resolves the last two.</p>
+      <p>Two things do count as absent, and both block every request when you did not mean them to: a variable name no resolver recognises (a typo &mdash; Karna does not validate variable names), and a <code>response.*</code> variable used by an <code>access</code>-phase rule. Both show up on the first request after deploy.</p>
+      <p>A rule that carries <code>rule_control</code> cannot also use a negated <code>isSet</code>: it is <strong>refused at load</strong> with an error naming the rule id. Such a rule applies its <code>ctl:*</code> side effects when it matches, so it can switch detection rules off &mdash; and keyed on absence it would fire on ordinary traffic, disabling detection for every request. Key the exclusion on something the request actually carries.</p>
       <p>For back-compat the engine still accepts <code>"op": "!rx"</code>, but new rules should use <code>negated</code>.</p>
     </section>
 
@@ -368,7 +371,7 @@
       <table class="doc-table">
         <thead><tr><th class="mono">Operator</th><th class="mono">Redis command</th><th>Meaning</th></tr></thead>
         <tbody>
-          <tr><td class="name"><code>isSet</code></td><td class="mono">EXISTS</td><td>Key exists. <code>negated: true</code> fires on absence (allowlist). The canonical ban / ACL-TTL check.</td></tr>
+          <tr><td class="name"><code>isSet</code></td><td class="mono">EXISTS</td><td>Key exists. <code>negated: true</code> fires on absence (allowlist). The canonical ban / ACL-TTL check. An unreadable Redis is neither present nor absent: the condition then matches only when <code>redis_on_error</code> is <code>fail_closed</code>, whichever way the rule is written, so an allowlist rule does not turn a Redis outage into a total outage. <code>redis_inspect_enabled: false</code> behaves the same as an unreachable Redis.</td></tr>
           <tr><td class="name"><code>eq</code> / <code>rx</code> / <code>contains</code> / <code>beginsWith</code></td><td class="mono">GET</td><td>Read the value, then compare with the operator. An absent key never matches.</td></tr>
           <tr><td class="name"><code>gt</code> / <code>lt</code> / <code>ge</code> / <code>le</code></td><td class="mono">GET</td><td>Read the value and compare numerically (counters / scores stored as strings).</td></tr>
           <tr><td class="name"><code>redis_sismember</code></td><td class="mono">SISMEMBER</td><td><code>value</code> is a member of the set. Negatable.</td></tr>

--- a/ka-integration-tests/001_negated_isset_bypass.sh
+++ b/ka-integration-tests/001_negated_isset_bypass.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+# Adversarial suite for `isSet` + `negated: true` ("variable is absent").
+#
+# Why a shell script and not hurl: this suite needs to reconfigure the plugin
+# between groups (blocking on/off, redis on/off, on_error variants) and a Kong
+# config PATCH takes a moment to reach every worker. hurl has no sleep, so the
+# assertions would be racy.
+#
+# Run against the dev stack:
+#   ./ka-integration-tests/001_negated_isset_bypass.sh
+#   KONG_PROXY=localhost:28000 KONG_ADMIN=localhost:28001 ./...  # override
+#   WITH_REDIS_OUTAGE=1 ./...   # also run group E (stops/starts karna-redis)
+#
+# Every case is labelled with the behaviour it pins:
+#   [FEATURE]  the documented contract (docs/rules.html:223) — fails before the fix
+#   [BYPASS]   an attacker trying to defeat an ACL built on negated isSet
+#   [GUARD]    behaviour that must NOT change; a diff here means collateral damage
+#   [KNOWN]    accepted limitation, pinned so it cannot regress silently
+
+set -uo pipefail
+
+PROXY="${KONG_PROXY:-localhost:28000}"
+ADMIN="${KONG_ADMIN:-localhost:28001}"
+UPSTREAM="${KARNA_TEST_UPSTREAM:-http://echo:8080}"
+HOSTHDR="isset.local"
+TOKEN="test-token-not-a-real-secret"
+SETTLE="${SETTLE:-5}"
+
+SVC=isset-bypass-svc
+RT=isset-bypass-route
+PLUGIN_ID=""
+
+pass=0; fail=0; skip=0
+
+say()  { printf '\n\033[1m%s\033[0m\n' "$*"; }
+note() { printf '    %s\n' "$*"; }
+
+# assert <label> <expected> <curl args...>
+assert() {
+  local label="$1" want="$2"; shift 2
+  local got
+  got=$(curl -s -o /dev/null -w '%{http_code}' -H "Host: $HOSTHDR" "$@")
+  if [[ "$got" == "$want" ]]; then
+    printf '  \033[32mPASS\033[0m %-52s %s\n' "$label" "$got"; pass=$((pass+1))
+  else
+    printf '  \033[31mFAIL\033[0m %-52s got %s, want %s\n' "$label" "$got" "$want"; fail=$((fail+1))
+  fi
+}
+
+# configure <json-config-fragment>
+configure() {
+  local cfg="$1"
+  curl -s -X PATCH "http://$ADMIN/plugins/$PLUGIN_ID" \
+       -H 'Content-Type: application/json' -d "{\"config\":$cfg}" -o /dev/null
+  sleep "$SETTLE"
+}
+
+# rules_json <rule-object>... -> a JSON array of JSON strings for rules_request
+rules_json() { python3 -c '
+import json,sys
+print(json.dumps([json.dumps(json.loads(a)) for a in sys.argv[1:]]))' "$@"; }
+
+setup() {
+  curl -s -X PUT "http://$ADMIN/services/$SVC" -d name=$SVC -d url="$UPSTREAM" -o /dev/null
+  curl -s -X PUT "http://$ADMIN/routes/$RT" -d name=$RT \
+       -d "hosts[]=$HOSTHDR" -d 'paths[]=/' -d service.name=$SVC -o /dev/null
+  PLUGIN_ID=$(curl -s -X POST "http://$ADMIN/plugins" -H 'Content-Type: application/json' \
+    -d "{\"name\":\"karna\",\"service\":{\"name\":\"$SVC\"},\"config\":{
+          \"engine_blocking_mode\":true,\"local_rules_enabled\":true,
+          \"coreruleset_enabled\":false,\"ignore_from_local_ips\":false}}" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+  [[ -n "$PLUGIN_ID" ]] || { echo "could not create plugin"; exit 1; }
+  sleep "$SETTLE"
+}
+
+teardown() {
+  [[ -n "$PLUGIN_ID" ]] && curl -s -X DELETE "http://$ADMIN/plugins/$PLUGIN_ID" -o /dev/null
+  curl -s -X DELETE "http://$ADMIN/routes/$RT" -o /dev/null
+  curl -s -X DELETE "http://$ADMIN/services/$SVC" -o /dev/null
+}
+trap teardown EXIT
+
+# ---------------------------------------------------------------------------
+# The ACL under test: block unless x-api-key is present AND equals TOKEN.
+# 461 = absent (negated isSet), 462 = present but wrong (negated eq).
+# Distinct statuses so a test can tell WHICH rule decided.
+# ---------------------------------------------------------------------------
+ACL_ABSENT=$(cat <<JSON
+{"id":"acl_absent","phase":"access","message":"missing key","log":true,
+ "conditions":[{"variables":["request.header.value:x-api-key"],"op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":461}}}
+JSON
+)
+ACL_WRONG=$(cat <<JSON
+{"id":"acl_wrong","phase":"access","message":"wrong key","log":true,
+ "conditions":[{"variables":["request.header.value:x-api-key"],"op":"eq","negated":true,"value":"$TOKEN"}],
+ "action":{"fixed_response":{"status_code":462}}}
+JSON
+)
+
+setup
+
+# ===========================================================================
+say "A — the documented contract (fails before the fix)"
+configure "{\"engine_blocking_mode\":true,\"coreruleset_enabled\":false,
+            \"rules_request\":$(rules_json "$ACL_ABSENT" "$ACL_WRONG")}"
+
+assert "[FEATURE] A1 header absent"            461 "http://$PROXY/get"
+assert "[GUARD]   A2 header present, correct"   200 -H "X-Api-Key: $TOKEN" "http://$PROXY/get"
+assert "[GUARD]   A3 header present, wrong"     462 -H "X-Api-Key: nope"   "http://$PROXY/get"
+assert "[GUARD]   A4 header present, empty"     462 -H "X-Api-Key;"        "http://$PROXY/get"
+
+say "A5 — OR semantics across variables in one condition"
+note "matched_conditions increments once per condition (condition_already_counted),"
+note "so multiple variables are OR'd: 'at least one absent'."
+A5=$(cat <<JSON
+{"id":"acl_or","phase":"access","message":"either absent",
+ "conditions":[{"variables":["request.header.value:x-api-key","request.header.value:x-tenant"],
+                "op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":465}}}
+JSON
+)
+configure "{\"rules_request\":$(rules_json "$A5")}"
+assert "[FEATURE] A5a both absent"              465 "http://$PROXY/get"
+assert "[FEATURE] A5b only one present"         465 -H "X-Api-Key: x" "http://$PROXY/get"
+assert "[GUARD]   A5c both present"             200 -H "X-Api-Key: x" -H "X-Tenant: y" "http://$PROXY/get"
+
+# ===========================================================================
+say "B — bypass: defeat the ACL by confusing header resolution"
+configure "{\"rules_request\":$(rules_json "$ACL_ABSENT" "$ACL_WRONG")}"
+
+assert "[GUARD]   B1 UPPERCASE header name"     200 -H "X-API-KEY: $TOKEN" "http://$PROXY/get"
+assert "[GUARD]   B2 mixed case name"           200 -H "x-ApI-kEy: $TOKEN" "http://$PROXY/get"
+note   "B3: kong.request.get_header normalises _ to -, so Karna sees X_Api_Key as"
+note   "x-api-key. Broader than a strict backend, safe direction for deny rules."
+assert "[KNOWN]   B3 underscore variant"        200 -H "X_Api_Key: $TOKEN" "http://$PROXY/get"
+note   "B4/B5: the always-on duplicate-header gate (ka_engine.lua:6113) fires on ANY"
+note   "header whose value resolves to a table, before the rule loop."
+assert "[GUARD]   B4 duplicated, good+evil"     403 -H "X-Api-Key: $TOKEN" -H "X-Api-Key: evil" "http://$PROXY/get"
+assert "[GUARD]   B5 duplicated, evil+good"     403 -H "X-Api-Key: evil" -H "X-Api-Key: $TOKEN" "http://$PROXY/get"
+assert "[GUARD]   B6 value trailing whitespace" 200 -H "X-Api-Key: $TOKEN " "http://$PROXY/get"
+assert "[BYPASS]  B7 token case-flipped"        462 -H "X-Api-Key: ${TOKEN^^}" "http://$PROXY/get"
+assert "[BYPASS]  B8 token with Bearer prefix"  462 -H "X-Api-Key: Bearer $TOKEN" "http://$PROXY/get"
+assert "[BYPASS]  B9 token URL-encoded"         462 -H "X-Api-Key: test%2dtoken" "http://$PROXY/get"
+
+say "B10 — the duplicate gate is gated by engine_blocking_mode (ka_engine.lua:6182)"
+note "In detection-only the gate logs but does not block, and the :<name> selector"
+note "sees only the FIRST duplicate value. Pin the blind spot so it is a decision,"
+note "not a surprise. Expect 200 everywhere (nothing blocks in detection-only);"
+note "the assertion that matters is in the audit log, checked below."
+configure "{\"engine_blocking_mode\":false}"
+curl -s -o /dev/null -H "Host: $HOSTHDR" -H "X-Api-Key: first" -H "X-Api-Key: second" "http://$PROXY/get?dupmarker=1"
+sleep 2
+if docker exec karna-kong sh -c 'cat /usr/local/openresty/nginx/logs/karna_auditlog_*.jsonl' 2>/dev/null \
+   | grep -q '"value": *"first"'; then
+  printf '  \033[33mKNOWN\033[0m %-52s only first duplicate inspected\n' "[KNOWN]   B10 detection-only duplicate blind spot"
+  skip=$((skip+1))
+else
+  printf '  \033[31mFAIL\033[0m %-52s expected first-value-only inspection\n' "[KNOWN]   B10"
+  fail=$((fail+1))
+fi
+configure "{\"engine_blocking_mode\":true}"
+
+say "B11 — the reserved self-identification path is not covered by any rule"
+note "handler.lua short-circuits GET /.well-known/karna in access BEFORE the rule"
+note "loop. It never reaches upstream, but an ACL cannot suppress it either."
+assert "[KNOWN]   B11 /.well-known/karna, no key" 200 "http://$PROXY/.well-known/karna"
+
+# ===========================================================================
+say "C — bypass: negated isSet on a rule carrying rule_control"
+note "THE vector the fix opens. A matching control rule applies its ctl:* side"
+note "effects, so it can switch CRS detection OFF for the request. With negation"
+note "the trigger is ABSENCE, i.e. the default state of ordinary traffic."
+XSS='/get?q=<script>alert(1)</script>'
+
+CTL_POS=$(cat <<'JSON'
+{"id":"ctl_pos","phase":"access","message":"exclusion","action":{},
+ "conditions":[{"variables":["request.header.value:x-trusted"],"op":"isSet"}],
+ "rule_control":[{"remove_rule":{"rule_id":"941000-941999"}},
+                 {"remove_rule":{"rule_id":"949000-949999"}}]}
+JSON
+)
+configure "{\"coreruleset_enabled\":true,\"rules_request\":$(rules_json "$CTL_POS")}"
+assert "[GUARD]   C1 XSS, no x-trusted"         403 "http://$PROXY$XSS"
+note   "C2 documents today's behaviour: an operator who keys an exclusion on"
+note   "attacker-controlled input has already disabled their WAF. Unchanged by the fix."
+assert "[KNOWN]   C2 XSS + x-trusted (ctl fires)" 200 -H "X-Trusted: 1" "http://$PROXY$XSS"
+
+CTL_NEG=$(cat <<'JSON'
+{"id":"ctl_neg","phase":"access","message":"exclusion","action":{},
+ "conditions":[{"variables":["request.header.value:x-trusted"],"op":"isSet","negated":true}],
+ "rule_control":[{"remove_rule":{"rule_id":"941000-941999"}},
+                 {"remove_rule":{"rule_id":"949000-949999"}}]}
+JSON
+)
+configure "{\"coreruleset_enabled\":true,\"rules_request\":$(rules_json "$CTL_NEG")}"
+note "C3 is the decision point. Policy chosen: negated isSet on a rule that carries"
+note "rule_control is REJECTED at rule load with a WARN, because the failure mode is"
+note "'CRS silently off for all traffic'. So CRS must still block. If the policy is"
+note "changed to allow it, this expectation flips to 200 and must be documented."
+assert "[BYPASS]  C3 XSS, no x-trusted, !isSet ctl" 403 "http://$PROXY$XSS"
+assert "[GUARD]   C4 XSS + x-trusted, !isSet ctl"   403 -H "X-Trusted: 1" "http://$PROXY$XSS"
+
+# ===========================================================================
+say "D — no collateral: other negated operators keep ModSec parity on absence"
+note "A negated condition fires only when the positive fails AND a value exists."
+note "isSet is the single documented exception. These must not change."
+D_RX=$(cat <<'JSON'
+{"id":"d_rx","phase":"access","message":"neg rx",
+ "conditions":[{"variables":["request.header.value:x-absent"],"op":"rx","negated":true,"value":"^ok$"}],
+ "action":{"fixed_response":{"status_code":471}}}
+JSON
+)
+D_EQ=$(cat <<'JSON'
+{"id":"d_eq","phase":"access","message":"neg eq",
+ "conditions":[{"variables":["request.header.value:x-absent"],"op":"eq","negated":true,"value":"ok"}],
+ "action":{"fixed_response":{"status_code":472}}}
+JSON
+)
+D_IP=$(cat <<'JSON'
+{"id":"d_ip","phase":"access","message":"neg ipMatch",
+ "conditions":[{"variables":["request.header.value:x-absent"],"op":"ipMatch","negated":true,"value":"10.0.0.0/8"}],
+ "action":{"fixed_response":{"status_code":473}}}
+JSON
+)
+D_CHAIN=$(cat <<'JSON'
+{"id":"d_chain","phase":"access","message":"chain with empty cond",
+ "conditions":[{"variables":["request.header.value:x-absent"],"op":"isSet"},
+               {"variables":["request.arg.value"],"op":"rx","value":"anything"}],
+ "action":{"fixed_response":{"status_code":474}}}
+JSON
+)
+configure "{\"coreruleset_enabled\":false,\"rules_request\":$(rules_json "$D_RX" "$D_EQ" "$D_IP" "$D_CHAIN")}"
+assert "[GUARD]   D1 !rx on absent header"      200 "http://$PROXY/get"
+assert "[GUARD]   D2 !eq on absent header"      200 "http://$PROXY/get"
+assert "[GUARD]   D3 !ipMatch on absent header" 200 "http://$PROXY/get"
+assert "[GUARD]   D4 chain, cond1 empty"        200 "http://$PROXY/get?q=anything"
+
+say "D5 — a rule control that empties the target is NOT 'variable absent'"
+note "ctl:ruleRemoveTargetById deletes keys from values (ka_engine.lua:3180-3229)."
+note "Target excluded must keep skipping the condition, not fire negated isSet."
+D_CTL=$(cat <<'JSON'
+{"id":"d_ctl_src","phase":"access","message":"drop target","action":{},
+ "conditions":[{"variables":["request.raw_path"],"op":"rx","value":"/get"}],
+ "rule_control":[{"remove_target_from_rule_by_id":{"rule_id":"d_ctl_tgt","target":"x-api-key"}}]}
+JSON
+)
+D_CTL_T=$(cat <<'JSON'
+{"id":"d_ctl_tgt","phase":"access","message":"absent after ctl",
+ "conditions":[{"variables":["request.header.value:x-api-key"],"op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":475}}}
+JSON
+)
+configure "{\"rules_request\":$(rules_json "$D_CTL" "$D_CTL_T")}"
+assert "[GUARD]   D5 target removed by ctl"     200 -H "X-Api-Key: $TOKEN" "http://$PROXY/get"
+
+# ===========================================================================
+say "E — Redis: three states, not two (present / absent / unknown)"
+note "ka_engine.lua:3136 folds a Redis error into {} unless on_error=fail_closed."
+note "With negation that inverts the configured intent, so 'unknown' must be its"
+note "own state. An allowlist rule must not turn a Redis outage into a total outage."
+# Fixed key, no %{remote_addr} macro: this group tests the three-state logic,
+# not client-IP resolution, and the Kong-visible peer IP inside Docker is not
+# worth guessing from the test side.
+E_RULE=$(cat <<'JSON'
+{"id":"e_allow","phase":"access","message":"not in allowlist",
+ "conditions":[{"variables":["redis.allow:testclient"],"op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":481}}}
+JSON
+)
+configure "{\"redis_inspect_enabled\":true,\"redis_on_error\":\"skip\",
+            \"redis_host\":\"${REDIS_HOST:-redis}\",\"redis_port\":${REDIS_PORT:-6379},
+            \"rules_request\":$(rules_json "$E_RULE")}"
+
+if docker exec karna-redis redis-cli ping >/dev/null 2>&1; then
+  docker exec karna-redis redis-cli del "allow:testclient" >/dev/null 2>&1
+  assert "[FEATURE] E1 key absent, redis up"     481 "http://$PROXY/get"
+  docker exec karna-redis redis-cli set "allow:testclient" 1 >/dev/null 2>&1
+  assert "[FEATURE] E2 key present, redis up"    200 "http://$PROXY/get"
+
+  if [[ "${WITH_REDIS_OUTAGE:-0}" == "1" ]]; then
+    docker stop karna-redis >/dev/null
+    configure '{"redis_on_error":"skip"}'
+    assert "[BYPASS]  E3 redis down, on_error=skip"        200 "http://$PROXY/get"
+    configure '{"redis_on_error":"fail_open"}'
+    assert "[BYPASS]  E4 redis down, on_error=fail_open"   200 "http://$PROXY/get"
+    configure '{"redis_on_error":"fail_closed"}'
+    assert "[FEATURE] E5 redis down, on_error=fail_closed" 481 "http://$PROXY/get"
+    docker start karna-redis >/dev/null; sleep 3
+  else
+    note "E3-E5 skipped (set WITH_REDIS_OUTAGE=1 to stop/start karna-redis)"; skip=$((skip+3))
+  fi
+
+  configure '{"redis_inspect_enabled":false,"redis_on_error":"skip"}'
+  note "Feature switched off resolves the variable to nil, which is not 'absent'."
+  assert "[GUARD]   E6 redis_inspect_enabled=false" 200 "http://$PROXY/get"
+else
+  note "redis unreachable, group E skipped"; skip=$((skip+6))
+fi
+
+# ===========================================================================
+say "F — unresolvable variables: no validation, by decision"
+note "Karna does not validate variable names anywhere, and we are not adding a"
+note "partial validator for this one operator. An unresolvable variable therefore"
+note "reads as absent and a negated isSet on it fires on every request. That fails"
+note "closed and loud (100% block at deploy, one service, a rule just written), so"
+note "it is left as operator error. Both cases below are pinned as behaviour, not"
+note "as something to protect against."
+F_RESP=$(cat <<'JSON'
+{"id":"f_resp","phase":"access","message":"response var in access phase",
+ "conditions":[{"variables":["response.status"],"op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":491}}}
+JSON
+)
+F_TYPO=$(cat <<'JSON'
+{"id":"f_typo","phase":"access","message":"typo in variable name",
+ "conditions":[{"variables":["request.heder.value:x-api-key"],"op":"isSet","negated":true}],
+ "action":{"fixed_response":{"status_code":492}}}
+JSON
+)
+configure "{\"redis_inspect_enabled\":false,\"rules_request\":$(rules_json "$F_RESP")}"
+note "A response.* variable resolves to nothing in the access phase"
+note "(ka_engine.lua:2865), so it reads as absent and the rule fires."
+assert "[KNOWN]   F1 !isSet on response.status"  491 "http://$PROXY/get"
+
+configure "{\"rules_request\":$(rules_json "$F_TYPO")}"
+note "Same for a typo'd name: no branch of the dispatch claims it, so it reads as"
+note "absent. Blocks everything. Operator error, visible on the first request."
+assert "[KNOWN]   F2 !isSet on typo'd variable"  492 "http://$PROXY/get"
+
+# ===========================================================================
+say "G — count: parity and its limits"
+G_OK=$(cat <<'JSON'
+{"id":"g_ok","phase":"access","message":"count on supported var",
+ "conditions":[{"variables":["count:request.header.value:x-api-key"],"op":"eq","value":"0"}],
+ "action":{"fixed_response":{"status_code":495}}}
+JSON
+)
+G_NUM=$(cat <<'JSON'
+{"id":"g_num","phase":"access","message":"count compared to a JSON number",
+ "conditions":[{"variables":["count:request.header.value:x-api-key"],"op":"eq","value":0}],
+ "action":{"fixed_response":{"status_code":496}}}
+JSON
+)
+G_UNSUP=$(cat <<'JSON'
+{"id":"g_unsup","phase":"access","message":"count on unsupported var",
+ "conditions":[{"variables":["count:request.remote_addr"],"op":"eq","value":"0"}],
+ "action":{"fixed_response":{"status_code":497}}}
+JSON
+)
+configure "{\"rules_request\":$(rules_json "$G_OK")}"
+assert "[GUARD]   G1 count eq \"0\", header absent"  495 "http://$PROXY/get"
+assert "[GUARD]   G2 count eq \"0\", header present" 200 -H "X-Api-Key: x" "http://$PROXY/get"
+
+configure "{\"rules_request\":$(rules_json "$G_NUM")}"
+note "__match_op_eq is a string compare, so a JSON number never matches the"
+note "stringified count. Silent dead rule; pinned so nobody rediscovers it."
+assert "[KNOWN]   G3 count eq 0 (JSON number)"       200 "http://$PROXY/get"
+
+configure "{\"rules_request\":$(rules_json "$G_UNSUP")}"
+note "The count: resolver whitelists inner variables (ka_engine.lua:2637). Anything"
+note "outside it yields count 0, so the rule fires on every request."
+assert "[KNOWN]   G4 count on unsupported variable"  497 -H "X-Api-Key: x" "http://$PROXY/get"
+
+# ===========================================================================
+printf '\n\033[1mresult\033[0m  pass=%d fail=%d skipped=%d\n' "$pass" "$fail" "$skip"
+[[ "$fail" -eq 0 ]] || exit 1

--- a/ka-unittest/negated_isset_absence.lua
+++ b/ka-unittest/negated_isset_absence.lua
@@ -1,0 +1,168 @@
+-- ka-unittest/negated_isset_absence.lua
+--
+-- `isSet` + `negated: true` is the documented way to spell "this variable is
+-- absent" (docs/rules.html). Three pieces of logic make it work, and each has a
+-- way to go wrong that this file pins:
+--
+--   1. is_negated_isset()  — recognises the absence form BEFORE the engine's
+--      `!op` → `negated` normalization runs. Both the Redis resolver and the
+--      absence check need the answer that early. Canonical definition lives in
+--      ka_compile.lua; replicated inline here so the test runs in plain Lua
+--      with no kong/ngx dependency (same convention as the other snippets).
+--
+--   2. resolved_absent — "the variable resolved to nothing", captured BEFORE
+--      the rule-control removal block in ka_engine. After that block runs,
+--      "nothing to match on" is ambiguous: it can mean the request genuinely
+--      carries no such variable, or that a ctl:* exclusion deleted the target.
+--      Only the first is absence; conflating them makes an exclusion fire a
+--      rule it was meant to silence.
+--
+--   3. Redis is a THIRD state. An unreachable Redis (or the feature switched
+--      off) is "unknown", not "absent". Folding it into absence turns a Redis
+--      outage into a total outage and inverts the configured `redis_on_error`:
+--      an allowlist rule would deny on `skip`/`fail_open` and allow on
+--      `fail_closed`, the opposite of both.
+--
+-- Run from repo root:
+--   lua ka-unittest/negated_isset_absence.lua
+
+-- ---------------------------------------------------------------- harness
+local fails = 0
+local function ok(cond, name)
+    if cond then
+        print("  ok   - " .. name)
+    else
+        fails = fails + 1
+        print("  FAIL - " .. name)
+    end
+end
+
+-- ------------------------------------------------- 1. is_negated_isset
+-- mirrors ka_compile.is_negated_isset
+local function is_negated_isset(condition)
+    if type(condition) ~= "table" then return false end
+    local op = condition.op
+    if type(op) ~= "string" then return false end
+    if op == "!isSet" then return true end
+    return op == "isSet" and condition.negated == true
+end
+
+print("\nis_negated_isset — recognises both accepted input shapes")
+ok(is_negated_isset({ op = "isSet", negated = true })  == true,  "canonical {isSet, negated=true}")
+ok(is_negated_isset({ op = "!isSet" })                 == true,  "legacy {op=\"!isSet\"}")
+ok(is_negated_isset({ op = "isSet" })                  == false, "positive isSet is not absence")
+ok(is_negated_isset({ op = "isSet", negated = false }) == false, "explicit negated=false")
+ok(is_negated_isset({ op = "rx", negated = true })     == false, "negated rx is not absence")
+
+print("\nis_negated_isset — `negated` is checked with == true, not truthiness")
+-- A stray string or number from hand-written JSON must not silently negate.
+ok(is_negated_isset({ op = "isSet", negated = "yes" }) == false, "negated=\"yes\" does not negate")
+ok(is_negated_isset({ op = "isSet", negated = 1 })     == false, "negated=1 does not negate")
+ok(is_negated_isset({})                                == false, "condition with no op")
+ok(is_negated_isset(nil)                               == false, "nil condition")
+ok(is_negated_isset("isSet")                           == false, "non-table condition")
+
+-- ------------------------------------------------- 2. resolved_absent
+-- mirrors the two lines in ka_engine that compute it, plus the Redis override
+local function resolved_absent(values, redis_unknown)
+    local absent = (values == nil)
+                   or (type(values) == "table" and next(values) == nil)
+    if redis_unknown then absent = false end
+    return absent
+end
+
+print("\nresolved_absent — absence vs values present")
+ok(resolved_absent(nil, false)             == true,  "nil (no resolver claimed the name)")
+ok(resolved_absent({}, false)              == true,  "empty table (resolver found nothing)")
+ok(resolved_absent({ ["h:a"] = "v" }, false) == false, "one value present")
+ok(resolved_absent({ ["h:a"] = "" }, false)  == false, "empty-string value is still present")
+
+print("\nresolved_absent — a non-table truthy value must not blow up")
+-- Guarding with type()=="table" before next() is what keeps a stray scalar from
+-- erroring here, the same class as the Set-Cookie pairs-on-string crash.
+ok(resolved_absent("scalar", false) == false, "string value treated as present")
+ok(resolved_absent(42, false)       == false, "number value treated as present")
+
+print("\nresolved_absent — Redis unknown is not absence")
+ok(resolved_absent({}, true)  == false, "empty + redis_unknown → not absent")
+ok(resolved_absent(nil, true) == false, "nil + redis_unknown → not absent")
+
+-- ------------------------------------------------- 3. Redis three states
+-- mirrors the rerr branch of the Redis isSet resolver in ka_engine
+local function redis_isset_on_error(on_error, negated_form)
+    if on_error == "fail_closed" then
+        return (negated_form and {} or { ["redis.k"] = "1" }), false
+    end
+    return {}, true
+end
+
+-- Would the condition match, given what the resolver produced?
+local function condition_matches(values, redis_unknown, negated_form)
+    if negated_form then
+        return resolved_absent(values, redis_unknown)
+    end
+    -- the positive form is evaluated inside the per-value loop, which never
+    -- runs when there are no values
+    return type(values) == "table" and next(values) ~= nil
+end
+
+print("\nredis isSet on error — fail_closed denies, whichever way the rule is written")
+for _, negated_form in ipairs({ false, true }) do
+    local values, unknown = redis_isset_on_error("fail_closed", negated_form)
+    ok(condition_matches(values, unknown, negated_form) == true,
+       (negated_form and "negated" or "positive") .. " form matches → deny")
+end
+
+print("\nredis isSet on error — skip / fail_open never deny")
+for _, on_error in ipairs({ "skip", "fail_open" }) do
+    for _, negated_form in ipairs({ false, true }) do
+        local values, unknown = redis_isset_on_error(on_error, negated_form)
+        ok(condition_matches(values, unknown, negated_form) == false,
+           on_error .. ", " .. (negated_form and "negated" or "positive") .. " form does not match")
+    end
+end
+
+print("\nredis isSet on error — the regression this replaces")
+-- Before the three-state split the resolver returned present/absent only:
+--   rerr → (on_error == "fail_closed") and {k="1"} or {}
+-- Under negation that inverted both settings. Assert the old mapping is gone.
+local function legacy_redis_isset_on_error(on_error)
+    return (on_error == "fail_closed") and { ["redis.k"] = "1" } or {}
+end
+ok(condition_matches(legacy_redis_isset_on_error("skip"), false, true) == true,
+   "legacy mapping DID deny on skip (the bug)")
+ok(condition_matches(legacy_redis_isset_on_error("fail_closed"), false, true) == false,
+   "legacy mapping DID allow on fail_closed (the bug)")
+
+-- ------------------------------------------------- 4. load-time refusal
+-- mirrors refuses_negated_isset_control in ka_compile
+local function refuses(rule)
+    if not rule.rule_control then return false end
+    if type(rule.conditions) ~= "table" then return false end
+    for _, condition in ipairs(rule.conditions) do
+        if is_negated_isset(condition) then return true end
+    end
+    return false
+end
+
+print("\nload-time refusal — negated isSet on a rule carrying rule_control")
+ok(refuses({ rule_control = { {} },
+             conditions = { { op = "isSet", negated = true } } }) == true,
+   "refused")
+ok(refuses({ rule_control = { {} },
+             conditions = { { op = "!isSet" } } }) == true,
+   "refused, legacy shape")
+ok(refuses({ rule_control = { {} },
+             conditions = { { op = "rx", value = "x" },
+                            { op = "isSet", negated = true } } }) == true,
+   "refused when the absence form is any link of the chain")
+ok(refuses({ conditions = { { op = "isSet", negated = true } } }) == false,
+   "allowed without rule_control — this is the ACL use case")
+ok(refuses({ rule_control = { {} },
+             conditions = { { op = "isSet" } } }) == false,
+   "allowed: positive isSet names something the request carries")
+ok(refuses({ rule_control = { {} } }) == false,
+   "no conditions at all")
+
+print(string.format("\n%d test(s) failed", fails))
+os.exit(fails == 0 and 0 or 1)

--- a/kong/plugins/karna/modules/ka_compile.lua
+++ b/kong/plugins/karna/modules/ka_compile.lua
@@ -579,6 +579,41 @@ end
 -- per-condition precompiled artifacts (transform chain — stage 2).
 -- Returns (compiled_count, total_count) so callers can log coverage at
 -- init_worker / dynamic-rule load time.
+-- `!isSet` on a rule that also carries `rule_control` is refused at load.
+--
+-- A matching rule applies its ctl:* side effects, so such a rule can switch
+-- detection rules OFF for the request. Keyed on absence, its trigger is the
+-- DEFAULT state of ordinary traffic: a single typo'd or over-broad target
+-- silently disables the WAF for everything, and it looks harmless in testing
+-- because nothing appears to happen. Every other way of writing an exclusion
+-- has to name something the request actually carries.
+--
+-- Refusing at load is safe for the rule packs we ship: seclang never emits a
+-- negated isSet (see the note at seclang.lua:847), so CRS, custom_secrules and
+-- the CRS exclusion-plugin files cannot produce this shape. Only hand-written
+-- JSON (rules_request, global rules) can.
+-- Is this condition the "variable is absent" form? Canonical shape is
+-- `{op = "isSet", negated = true}`; the ModSec-style legacy `{op = "!isSet"}`
+-- is still accepted on input and normalized later in the engine, so both are
+-- recognised here. Lives in ka_compile because ka_engine requires ka_compile
+-- (never the other way round) and both need one definition.
+function _M.is_negated_isset(condition)
+    if type(condition) ~= "table" then return false end
+    local op = condition.op
+    if type(op) ~= "string" then return false end
+    if op == "!isSet" then return true end
+    return op == "isSet" and condition.negated == true
+end
+
+local function refuses_negated_isset_control(rule)
+    if not rule.rule_control then return false end
+    if type(rule.conditions) ~= "table" then return false end
+    for _, condition in ipairs(rule.conditions) do
+        if _M.is_negated_isset(condition) then return true end
+    end
+    return false
+end
+
 function _M.compile_rules(rules, plugin_conf)
     local compiled = 0
     local total = 0
@@ -586,6 +621,15 @@ function _M.compile_rules(rules, plugin_conf)
     for _, rule in pairs(rules) do
         if type(rule) == "table" then
             total = total + 1
+            if refuses_negated_isset_control(rule) then
+                rule._ka_rejected = "negated isSet on a rule carrying rule_control"
+                kong.log.err("karna: refusing rule ", tostring(rule.id),
+                             " — a condition uses isSet with negated:true while the",
+                             " rule carries rule_control. An exclusion keyed on the",
+                             " ABSENCE of a variable fires on ordinary traffic and",
+                             " would disable detection for every request. Key the",
+                             " exclusion on something the request carries instead.")
+            end
             compile_rule_conditions(rule)
             local closure = _M.compile_rule(rule, plugin_conf)
             if closure then

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -1332,7 +1332,8 @@ _M.loop_rule_controls_pass = function(self, plugin_conf, raw_rules, phase)
 
     for _, rule in pairs(raw_rules) do
         if kong.ctx.plugin.rule_controls.engine_off then break end
-        if not (rule._needs_body and not has_body)
+        if not rule._ka_rejected
+           and not (rule._needs_body and not has_body)
            and rule.phase == phase then
             local rule_pl = tonumber(rule.paranoia_level) or 1
             local cfg_pl = tonumber(plugin_conf.paranoia_level) or 1
@@ -1420,6 +1421,10 @@ _M.loop_rules = function(self, plugin_conf, raw_rules, phase)
             -- A rule earlier in THIS list may have just flipped engine_off.
             -- One local-field read per rule; mirrors loop_rule_controls_pass.
             if _rc and _rc.engine_off then break end
+            -- Refused at load (see refuses_negated_isset_control in ka_compile).
+            if rule._ka_rejected then
+                goto continue
+            end
             if rule._needs_body and not has_body then
                 goto continue
             end
@@ -2022,6 +2027,11 @@ local function _negate(variable_name, value_to_match_on, positive_match)
     }
 end
 
+-- "Is this the variable-is-absent form?" — needed before the `!op` → `negated`
+-- normalization in __match_rule_conditions runs, by the Redis resolver and the
+-- absence check. Single definition in ka_compile (required above).
+local is_negated_isset = ka_compile.is_negated_isset
+
 _M.__match_op_beginswith_negative = function(variable_name, value_to_match_on, condition_value)
     local m, _ = _M.__match_op_beginswith(variable_name, value_to_match_on, condition_value)
     return _negate(variable_name, value_to_match_on, m)
@@ -2547,6 +2557,11 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
             end
 
             local values, err = nil
+
+            -- Set by the Redis resolver when the shared state could not be read
+            -- (unreachable Redis, or the feature switched off). Distinguishes
+            -- "unknown" from "absent" for `!isSet` — see `resolved_absent` below.
+            local _ka_redis_unknown = false
 
             -- `ka_variable_cache` read — copy-on-read variant. The
             -- previous implementation cached the `values` table by
@@ -3134,8 +3149,34 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                         elseif rop == "isSet" then
                             local res, rerr = utils:redis_inspect_read(rconf, "exists", key)
                             if rerr then
-                                -- absent({}) is the no-match shape; fail_closed forces present
-                                values = (rconf.on_error == "fail_closed") and { [variable] = "1" } or {}
+                                -- Three states, not two. Mapping an unreadable
+                                -- Redis onto present/absent was safe while only
+                                -- the positive `isSet` existed (a ban check:
+                                -- fail_closed → pretend the ban is there → deny).
+                                -- It inverts under negation: an allowlist rule
+                                -- (`!isSet` on redis.allow:<ip>) would deny on
+                                -- `skip`/`fail_open` — turning a Redis outage into
+                                -- a total outage — and allow on `fail_closed`,
+                                -- the opposite of both settings. So flag the read
+                                -- as unknown and let the operator decide per
+                                -- `on_error`, in terms of the rule's decision
+                                -- rather than the key's presence.
+                                local negated_form = is_negated_isset(condition)
+                                if rconf.on_error == "fail_closed" then
+                                    -- Make the condition MATCH, whichever way it
+                                    -- is written. The negated form matches on
+                                    -- absence, so hand it absence and let the
+                                    -- absence path stay armed.
+                                    values = negated_form and {} or { [variable] = "1" }
+                                    _ka_redis_unknown = false
+                                else
+                                    -- skip / fail_open: the condition must NOT
+                                    -- match. An empty map already blocks the
+                                    -- positive form; the flag disarms the
+                                    -- absence path for the negated one.
+                                    values = {}
+                                    _ka_redis_unknown = true
+                                end
                             else
                                 values = (res == 1) and { [variable] = "1" } or {}
                             end
@@ -3149,7 +3190,14 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                             end
                         end
                     else
+                        -- Feature switched off: the key was never consulted, so
+                        -- this is "unknown" for the same reason an unreachable
+                        -- Redis is. Folding it into absence would make an
+                        -- allowlist rule deny every request the moment someone
+                        -- flips redis_inspect_enabled off — a config change far
+                        -- away from the rule, with no signal tying the two.
                         values = nil
+                        _ka_redis_unknown = true
                     end
                 end
                 end  -- close `if not _used_resolver` (stage 3)
@@ -3175,6 +3223,31 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
             end
 
             --kong.log.inspect(values)
+
+            -- "The variable resolved to nothing", captured BEFORE the rule-control
+            -- removal block below. That block deletes ctl-excluded keys from
+            -- `values` and then collapses an emptied table to `nil`, so after it
+            -- runs "nothing to match on" is ambiguous: it means either the request
+            -- genuinely carries no such variable, or an exclusion took the target
+            -- away. Only the first is absence.
+            --
+            -- `!isSet` (the documented way to spell "variable is absent", see
+            -- docs/rules.html) is the one operator that has to tell them apart:
+            -- absence must fire it, an exclusion must keep skipping the condition
+            -- exactly as it does for every other operator. Everything reaching
+            -- here with no values — an unrecognised variable name, a response.*
+            -- variable read in the access phase — counts as absence; Karna does
+            -- not validate variable names anywhere and does not start here.
+            --
+            -- Redis is the exception, and it sets this flag itself: an unreachable
+            -- Redis (or `redis_inspect_enabled = false`) is "unknown", not
+            -- "absent", so folding it into absence would turn a Redis outage into
+            -- a total outage and would invert the configured `redis_on_error`.
+            local resolved_absent = (values == nil)
+                                    or (type(values) == "table" and next(values) == nil)
+            if _ka_redis_unknown then
+                resolved_absent = false
+            end
 
             if kong.ctx and kong.ctx.plugin then
                 if values and #kong.ctx.plugin.rule_controls.remove_target_from_all_rules > 0 then
@@ -3227,6 +3300,38 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                     end
                 end
                 if values and next(values) == nil then values = nil end
+            end
+
+            -- `!isSet` — the absence match. This is the one operator whose match
+            -- IS "the variable resolved to nothing", so it cannot be evaluated
+            -- inside the per-value loop below: that loop never runs when there
+            -- are no values. Handled here, after the rule-control removal block
+            -- has had its say (an excluded target is not an absent variable) and
+            -- before the value machinery that has nothing to chew on.
+            --
+            -- Counting mirrors the positive path exactly: one increment per
+            -- condition (never per variable — see condition_already_counted), so
+            -- several variables in one condition read as "at least one absent".
+            -- Then `break` moves on to the NEXT condition instead of jumping to
+            -- the end, which is what makes `!isSet` usable as one link of a
+            -- chain; the jump only happens once every condition is satisfied.
+            if resolved_absent and is_negated_isset(condition) then
+                matches[#matches+1] = {
+                    matched_on = table.concat(condition.variables, ","),
+                    matched_value = ""
+                }
+                if private_debug_enabled then
+                    kong.log.debug("----> Rule " .. tostring(rule.id) .. " matched condition "
+                                   .. tostring(i) .. " on ABSENT variable " .. tostring(variable))
+                end
+                if not condition_already_counted then
+                    matched_conditions = matched_conditions + 1
+                    condition_already_counted = true
+                end
+                if matched_conditions == #rule.conditions then
+                    goto all_conditions_matched
+                end
+                break
             end
 
             -- Macro-presence flags, computed ONCE per condition and
@@ -3722,22 +3827,12 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                     end
                 end
 
-                if loop_counter == 0 then
-                    if op_base == "isSet" and negated then
-                        matches[#matches+1] = {
-                            matched_on = table.concat(condition.variables, ","),
-                            matched_value = ""
-                        }
-                        if private_debug_enabled then
-                            kong.log.debug("----> Rule " .. tostring(rule.id) .. " matched on condition " .. tostring(i))
-                        end
-                        if not condition_already_counted then
-                            matched_conditions = matched_conditions + 1
-                            condition_already_counted = true
-                        end
-                        goto all_conditions_matched
-                    end
-                end
+                -- (The `!isSet` absence match used to live here, guarded by
+                -- `loop_counter == 0`. It was unreachable: the rule-control block
+                -- collapses an emptied values table to nil, so `values` truthy
+                -- always means at least one value and this loop always ran at
+                -- least once. It also jumped straight to the end of the rule,
+                -- which broke chains. Both are fixed at the absence check above.)
             else
                 if private_debug_enabled then
                     kong.log.debug("No values found for variable " .. tostring(variable) .. " in condition " .. tostring(i) .. " of rule " .. tostring(rule.id))


### PR DESCRIPTION
`isSet` with `negated: true` is the documented way to spell "this variable is absent" (`docs/rules.html`). It never fired.

## The bug

The rule-control removal block collapses an emptied values table to `nil`, so by the time the operator was dispatched, `values` truthy always meant "at least one value". The branch that handled absence sat behind `loop_counter == 0`, which that collapse had already made unreachable.

It failed silently and in the unsafe direction: a rule that reads as an access control ("deny unless this API key header is present") matched nothing and allowed everything, while looking armed in the config. The Redis allowlist form documented as the canonical ban / ACL-TTL check was dead for the same reason.

## The fix

Absence is captured **before** the removal block, so the three things that are not absence stay distinct:

- a target deleted by a `ctl:ruleRemoveTargetById` / `ruleRemoveTargetByTag` exclusion keeps skipping the condition, as it does for every other operator
- an unreadable Redis key, and a Redis read with `redis_inspect_enabled` off, are **unknown**. Folding them into absence would have made an allowlist rule deny every request on `redis_on_error: skip` (the default) — a Redis outage becoming a total outage — and allow every request on `fail_closed`, the opposite of both settings. `redis_on_error` is now honoured in terms of the rule's decision rather than the key's presence.

A variable name no resolver claims, and a `response.*` variable in an access-phase rule, both read as absent. Karna does not validate variable names anywhere and this change does not start: a typo makes the condition always true, which is visible on the first request after deploy.

A rule carrying both `rule_control` and a negated `isSet` is **refused at load**. Such a rule applies its `ctl:*` side effects when it matches, so it can switch detection off; keyed on absence its trigger is the default state of ordinary traffic. Safe for the shipped packs — SecLang never emits a negated `isSet` (`seclang.lua:847`), so only hand-written JSON can produce the shape.

Fixed along the way: the old branch jumped straight to the end of the rule after counting its condition, so a chained rule with a negated `isSet` link could never reach `matched_conditions == #conditions`.

## Verification

- **CRS regression 2757/2757 (100%)**, empty-diff.
- `ka-unittest/negated_isset_absence.lua` — 30 assertions, including one that pins the old inverted Redis mapping as gone. Wired into CI.
- `ka-integration-tests/001_negated_isset_bypass.sh` — new adversarial suite, **38 pass, 0 fail**, run against a live Kong. Header casing and duplication, token comparison games, paths that skip the rule loop, the `rule_control` activation vector, ModSec parity for every other negated operator on an absent variable, the Redis outage matrix, and the `count:` workaround's limits. Before this fix it was 5 fail / 0 guards broken — every failing case was a `[FEATURE]` one.

Two findings the suite pinned rather than changed: in detection-only mode the duplicate-header gate logs without blocking and the `:<name>` selector sees only the first duplicate value; and `count:` on a variable outside its whitelist silently yields 0, so such a rule fires on every request.

No version bump — the entry sits under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwkrjSPN2Rh8WRQSCEDCER