### PR TITLE
fix(engine): custom_secrules with a disruptive action never blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
         run: lua ka-unittest/op_negation_normalization.lua
       - name: Negated isSet absence (ctl vs absent, Redis three states, load-time refusal)
         run: lua ka-unittest/negated_isset_absence.lua
+      - name: custom_secrules controls/detection split (+ nolog/auditlog flags)
+        run: lua ka-unittest/custom_secrules_split.lua
       - name: JSON embedded in urlencoded values (flatten regression guard)
         run: lua ka-unittest/json_in_urlencoded.lua
       - name: Redis inspection read helper (whitelist + connection behavior)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- An inline `custom_secrules` rule with a disruptive action never blocked. Rules
+  from that channel (and from the CRS exclusion-plugin `.conf` files) were handed
+  to a single evaluator, the multi-match controls path, which deliberately ignores
+  `fixed_response` because it exists to collect `ctl:*` side effects. So a
+  hand-written `SecRule ... "id:1,phase:1,block"` was parsed, evaluated on every
+  request, matched — and had its terminal action discarded. `schema.lua` described
+  the intended behaviour ("added to the global rule pool"), but nothing wired it
+  up. Nothing was wrong with the parsed rule: `REQUEST_URI` resolves, `phase:1`
+  maps to access, and `__get_action` already emits `fixed_response` for both
+  `block` and `deny` — CRS rules come out of the same parser and do block.
+  - The channel is now pre-split into `controls` and `detection` and both halves
+    are evaluated, reusing the classifier the global rules pack already uses
+    (`rule_control` with no action → controls; anything with a real action →
+    detection, so a rule carrying `rule_control` next to `setvar` / `set_variable`
+    does not lose its side effects). The split is computed once per (worker,
+    plugin_conf) and cached with the parse, so there is no per-request cost —
+    Kong hands out a new `plugin_conf` table on every Admin API write, which
+    invalidates the cache by itself.
+  - Net effect on throughput is neutral to positive: these rules were already
+    being evaluated on every request, just to no purpose. The controls half costs
+    what it did before, and the detection half now runs on the first-terminal-
+    match-wins path, which can exit early where the multi-match path could not.
+  - Detection rules run in the same slot as their own exclusions, ahead of global,
+    local and CRS rules: a rule an operator wrote by hand for one service wins
+    over the shipped packs.
+  - `phase:3` rules from this channel now run. seclang has always mapped `phase:3`
+    to header_filter, but the channel was only ever evaluated in access, so such a
+    rule did nothing at all.
+- A matching `custom_secrules` / CRS-plugin rule now reaches the audit log. The
+  log phase gates each record on `rule.log`, and only the CRS loader set it
+  (`ka_engine.lua:531`) — rules parsed through `seclang.parse_isolated` never went
+  through that loader, so they matched, acted, and left no trace. seclang now reads
+  ModSec's logging flags off the action list: `auditlog` on, `noauditlog` off,
+  `nolog` off, default on, with `noauditlog` tested first because `auditlog` is a
+  substring of it. `nolog,auditlog` — the CRS idiom for "no error log, yes audit
+  log" — logs, since the audit log is the only log Karna has. Flags are matched on
+  comma boundaries so the free text in `msg:'…'` and `logdata:'…'` is not read as
+  a flag.
+- Covered by `ka-unittest/custom_secrules_split.lua` (the classifier truth table
+  both copies must implement, bucketing including author order and dropped phases,
+  and the logging flags). CRS regression 2757/2757, unchanged.
+
 ### Security
 
 - `isSet` with `negated: true` — the documented way to spell "this variable is

--- a/ka-unittest/custom_secrules_split.lua
+++ b/ka-unittest/custom_secrules_split.lua
@@ -1,0 +1,178 @@
+-- ka-unittest/custom_secrules_split.lua
+--
+-- Inline `custom_secrules` (and the CRS exclusion-plugin .conf files) used to be
+-- handed to ONE evaluator: the multi-match controls path, which deliberately
+-- ignores `fixed_response`. A hand-written `SecRule ... "deny"` was therefore
+-- parsed, evaluated on every request, matched — and had its terminal action
+-- silently discarded. The rules are now split by the same rule the global rules
+-- pack uses, and the detection half goes to the standard action dispatch.
+--
+-- Three pieces of logic, each with a way to go wrong:
+--
+--   1. is_control_only() — decides the bucket. Canonical copy is
+--      `ka_compile.is_control_only`; `ka_global_rules` carries a duplicate
+--      because it must stay requirable without ka_compile (its engine/compile
+--      refs are injected via init() so it can be unit-tested in plain Lua). The
+--      two MUST agree, and this truth table is the shared contract. Replicated
+--      inline here, the same convention op_negation_normalization.lua uses:
+--      neither ka_compile nor seclang loads under the Lua 5.4 CI runs.
+--
+--   2. The bucketing itself — right bucket, right phase, and a rule whose phase
+--      this channel never evaluates must be dropped rather than parked where it
+--      would silently never run.
+--
+--   3. __get_log() — whether a match earns an audit-log entry. The CRS loader
+--      sets `rule.log` on everything it loads; rules arriving through
+--      parse_isolated never went through it, so they blocked without leaving a
+--      trace. Reads ModSec's nolog / auditlog / noauditlog off the action list.
+--
+-- Run from repo root:
+--   lua ka-unittest/custom_secrules_split.lua
+
+local fails = 0
+local function ok(cond, name)
+    if cond then
+        print("  ok   - " .. name)
+    else
+        fails = fails + 1
+        print("  FAIL - " .. name)
+    end
+end
+
+-- ------------------------------------------------- 1. is_control_only
+-- mirrors ka_compile.is_control_only / the duplicate in ka_global_rules
+local function is_control_only(rule)
+    if type(rule.rule_control) ~= "table" then return false end
+    local action = rule.action
+    if action == nil then return true end
+    if type(action) ~= "table" then return false end
+    return next(action) == nil
+end
+
+print("\nis_control_only — an exclusion is rule_control with no action")
+ok(is_control_only({ rule_control = { {} } })                    == true,
+   "rule_control, action absent")
+ok(is_control_only({ rule_control = { {} }, action = {} })       == true,
+   "rule_control, action empty table")
+ok(is_control_only({ rule_control = {}, action = {} })           == true,
+   "empty rule_control list still counts as a control rule")
+
+print("\nis_control_only — anything carrying a real action is detection")
+ok(is_control_only({ action = { fixed_response = { status_code = 403 } } }) == false,
+   "action, no rule_control")
+ok(is_control_only({ rule_control = { {} },
+                     action = { fixed_response = { status_code = 403 } } }) == false,
+   "rule_control NEXT TO an action stays detection")
+-- This is the case the split exists to protect: the controls path runs no action
+-- side effects, so a rule with setvar / set_log_fields / redis_incr_key next to
+-- its rule_control would lose them if it were filed as a control.
+ok(is_control_only({ rule_control = { {} },
+                     action = { set_variable = { name = "x" } } }) == false,
+   "rule_control next to a side-effect action stays detection")
+ok(is_control_only({})                                           == false,
+   "no rule_control at all")
+ok(is_control_only({ rule_control = "notatable" })               == false,
+   "rule_control of the wrong type")
+ok(is_control_only({ rule_control = { {} }, action = "deny" })   == false,
+   "action of the wrong type is not an empty action")
+
+-- ------------------------------------------------- 2. bucketing
+-- mirrors the split loop in handler.get_plugin_dynamic_rules
+local function split(parsed)
+    local out = {
+        controls  = { access = {}, header_filter = {} },
+        detection = { access = {}, header_filter = {} },
+    }
+    local dropped = 0
+    for _, rule in ipairs(parsed) do
+        local bucket = is_control_only(rule) and out.controls or out.detection
+        local phase_list = bucket[rule.phase]
+        if phase_list then
+            phase_list[#phase_list + 1] = rule
+        else
+            dropped = dropped + 1
+        end
+    end
+    return out, dropped
+end
+
+local BLOCK_A = { id = "1", phase = "access",        action = { fixed_response = {} } }
+local BLOCK_H = { id = "2", phase = "header_filter", action = { fixed_response = {} } }
+local EXCL_A  = { id = "3", phase = "access",        rule_control = { {} } }
+local EXCL_H  = { id = "4", phase = "header_filter", rule_control = { {} } }
+local BODY    = { id = "5", phase = "body_filter",   action = { fixed_response = {} } }
+local TYPO    = { id = "6", phase = "acess",         action = { fixed_response = {} } }
+
+print("\nbucketing — each rule lands in one bucket and one phase")
+local s, dropped = split({ BLOCK_A, BLOCK_H, EXCL_A, EXCL_H })
+ok(#s.detection.access == 1 and s.detection.access[1].id == "1", "block/access → detection.access")
+ok(#s.detection.header_filter == 1 and s.detection.header_filter[1].id == "2",
+   "block/header_filter → detection.header_filter")
+ok(#s.controls.access == 1 and s.controls.access[1].id == "3", "excl/access → controls.access")
+ok(#s.controls.header_filter == 1 and s.controls.header_filter[1].id == "4",
+   "excl/header_filter → controls.header_filter")
+ok(dropped == 0, "nothing dropped")
+
+print("\nbucketing — a phase this channel never evaluates is dropped, not parked")
+s, dropped = split({ BODY, TYPO })
+ok(dropped == 2, "body_filter and a typo'd phase both dropped")
+ok(#s.detection.access == 0 and #s.detection.header_filter == 0, "neither leaked into a phase")
+
+print("\nbucketing — author order is preserved within a bucket")
+local r1 = { id = "10", phase = "access", action = { fixed_response = {} } }
+local r2 = { id = "11", phase = "access", action = { fixed_response = {} } }
+local r3 = { id = "12", phase = "access", action = { fixed_response = {} } }
+s = split({ r1, r2, r3 })
+ok(s.detection.access[1].id == "10" and s.detection.access[2].id == "11"
+   and s.detection.access[3].id == "12",
+   "first-match-wins sees the rules in the order they were written")
+
+print("\nbucketing — an empty input yields empty lists, not nil")
+s, dropped = split({})
+ok(#s.controls.access == 0 and #s.detection.access == 0
+   and #s.controls.header_filter == 0 and #s.detection.header_filter == 0,
+   "all four lists present and empty")
+ok(dropped == 0, "nothing dropped")
+
+-- ------------------------------------------------- 3. __get_log
+-- mirrors seclang.__get_log
+local function get_log(actions)
+    local padded = "," .. (actions or "") .. ","
+    local function has(flag)
+        return string.find(padded, "," .. flag .. ",", 1, true) ~= nil
+    end
+    if has("noauditlog") then return false end
+    if has("auditlog") then return true end
+    if has("nolog") then return false end
+    return true
+end
+
+print("\n__get_log — ModSec logging flags")
+ok(get_log("id:1,phase:1,block")                  == true,  "default is on")
+ok(get_log("id:1,nolog")                          == false, "nolog disables")
+ok(get_log("id:1,auditlog")                       == true,  "auditlog enables")
+ok(get_log("id:1,nolog,auditlog")                 == true,  "nolog,auditlog → on (the CRS idiom)")
+ok(get_log("id:1,auditlog,nolog")                 == true,  "order does not matter")
+ok(get_log("id:1,noauditlog")                     == false, "noauditlog disables")
+ok(get_log("id:1,noauditlog,auditlog")            == false, "noauditlog wins, it is checked first")
+ok(get_log(nil)                                   == true,  "nil actions → default on")
+ok(get_log("")                                    == true,  "empty actions → default on")
+
+print("\n__get_log — a flag at either end of the list is still a flag")
+ok(get_log("nolog,id:1")                          == false, "first position")
+ok(get_log("id:1,nolog")                          == false, "last position")
+ok(get_log("nolog")                               == false, "only element")
+
+print("\n__get_log — free text must not be read as a flag")
+-- The actions string carries msg:'…' and logdata:'…'. Comma-delimited matching
+-- is what keeps their contents out of the decision.
+ok(get_log("id:1,msg:'nolog is not set here'")    == true,  "nolog inside msg")
+ok(get_log("id:1,msg:'see auditlog docs',nolog")  == false, "auditlog inside msg does not enable")
+ok(get_log("id:1,logdata:'nologistics'")          == true,  "flag as a substring of a word")
+ok(get_log("id:1,tag:'auditlog-related'")         == true,  "auditlog as a prefix inside a tag")
+-- Honest limit: a msg that itself contains a comma-delimited flag does fool it.
+-- Pinned so the boundary is a known property rather than a surprise.
+ok(get_log("id:1,msg:'a,nolog,b'")                == false, "known limit: ,flag, inside msg does match")
+
+print(string.format("\n%d test(s) failed", fails))
+os.exit(fails == 0 and 0 or 1)

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -84,6 +84,22 @@ local load_plugin_dynamic_rules = function(plugin_conf)
   return out
 end
 
+-- The parsed dynamic rules, pre-split into the two evaluator paths and cached
+-- with the parse. Same shape and same reason as the global rules pack:
+-- `controls` (exclusions — only rule_control, no action) go on the multi-match
+-- pass path, `detection` (anything carrying a real action) on the standard
+-- first-terminal-match-wins path.
+--
+-- Before this split, everything here went to the pass path only, which
+-- deliberately ignores `fixed_response` — so an inline `SecRule ... "deny"` in
+-- `custom_secrules` was parsed, matched, and had its terminal action silently
+-- discarded. The rules were already being evaluated on every request; only the
+-- result was thrown away.
+--
+-- Splitting here rather than per request means it is paid once per (worker,
+-- plugin_conf): Kong hands us a new plugin_conf table on every Admin API write,
+-- so the cache key invalidates itself. Mirrors get_local_request_rules, which
+-- precomputes its own per-phase subsets for the same reason.
 local get_plugin_dynamic_rules = function(plugin_conf)
   local key = "plugin_dyn_rules:" .. tostring(plugin_conf)
   local cached = ka_rules:get(key)
@@ -93,8 +109,25 @@ local get_plugin_dynamic_rules = function(plugin_conf)
   -- passed so private_debug source dumps respect the per-service flag.
   -- See ka_compile.compile_rule for the contract.
   ka_compile.compile_rules(parsed, plugin_conf)
-  ka_rules:set(key, parsed)
-  return parsed
+
+  local split = {
+    all = parsed,
+    controls  = { access = {}, header_filter = {} },
+    detection = { access = {}, header_filter = {} },
+  }
+  for _, rule in ipairs(parsed) do
+    local bucket = ka_compile.is_control_only(rule) and split.controls or split.detection
+    local phase_list = bucket[rule.phase]
+    -- A phase this channel never evaluates (body_filter, mcp_event, or a typo
+    -- in `phase:N`) lands nowhere rather than being parked where it would never
+    -- run. seclang maps phase:1/2 to access and phase:3 to header_filter.
+    if phase_list then
+      phase_list[#phase_list + 1] = rule
+    end
+  end
+
+  ka_rules:set(key, split)
+  return split
 end
 
 -- Parse + compile the rules carried inline by `plugin_conf.rules_request`
@@ -845,8 +878,17 @@ function plugin:access(plugin_conf)
   -- — every matching pass-rule contributes its ctl:* side-effects
   -- (the wp-rule-exclusions plugin alone fires multiple rules per
   -- WordPress endpoint, each whitelisting a different ARGS target).
+  --
+  -- Detection rules from the same source (an inline `SecRule ... "deny"`, or a
+  -- CRS plugin rule that blocks rather than excludes) run right after their own
+  -- exclusions, in this same slot. That puts them AHEAD of global, local and CRS
+  -- rules: a rule an operator wrote by hand for this specific service wins over
+  -- the shipped packs, and its ctl:* siblings have already been applied.
   local plugin_dyn_rules = get_plugin_dynamic_rules(plugin_conf)
-  apply_pass_rule_controls(plugin_conf, plugin_dyn_rules, "access")
+  apply_pass_rule_controls(plugin_conf, plugin_dyn_rules.controls.access, "access")
+  if #plugin_dyn_rules.detection.access > 0 then
+    evaluate_rules(plugin_conf, plugin_dyn_rules.detection.access, "access")
+  end
 
   -- Diagnostic dump of the resolved rule_controls. This used to run
   -- unconditionally on every access request (a full inspect-library
@@ -914,7 +956,20 @@ function plugin:header_filter(plugin_conf)
   -- generate global inspection table
   engine:get_inspection_table(plugin_conf)
 
-  -- Global rules first (same precedence and controls-then-detection split as
+  -- CRS exclusion plugins + inline custom_secrules, response phase. seclang maps
+  -- `phase:3` to header_filter, but before the controls/detection split this
+  -- channel was only ever evaluated in access, so such a rule did nothing at
+  -- all. Same order as the access phase: this rule's own exclusions, then its
+  -- detection, then the shipped packs.
+  local plugin_dyn_rules = get_plugin_dynamic_rules(plugin_conf)
+  if #plugin_dyn_rules.controls.header_filter > 0 then
+    apply_pass_rule_controls(plugin_conf, plugin_dyn_rules.controls.header_filter, "header_filter")
+  end
+  if #plugin_dyn_rules.detection.header_filter > 0 then
+    evaluate_rules(plugin_conf, plugin_dyn_rules.detection.header_filter, "header_filter")
+  end
+
+  -- Global rules next (same precedence and controls-then-detection split as
   -- the access phase: see the comment there). Uses the pack snapshot pinned by
   -- :access; requests that skipped access (cache hit) skip here too via the
   -- response_from_cache guard above.

--- a/kong/plugins/karna/modules/ka_compile.lua
+++ b/kong/plugins/karna/modules/ka_compile.lua
@@ -592,6 +592,24 @@ end
 -- negated isSet (see the note at seclang.lua:847), so CRS, custom_secrules and
 -- the CRS exclusion-plugin files cannot produce this shape. Only hand-written
 -- JSON (rules_request, global rules) can.
+-- Exclusion rules (only `rule_control`, no action) belong on the multi-match
+-- controls path; everything else keeps the standard action dispatch. A rule
+-- carrying `rule_control` NEXT TO a real action stays in detection, because the
+-- controls path deliberately does not run action side effects (set_variable /
+-- set_log_fields / redis_incr_key would be silently lost).
+--
+-- Used by every channel that mixes exclusions and detection in one list: the
+-- global rules pack and the per-plugin dynamic rules (CRS exclusion plugins +
+-- inline `custom_secrules`). One definition so a rule is filed the same way
+-- whichever channel it arrives on.
+function _M.is_control_only(rule)
+    if type(rule.rule_control) ~= "table" then return false end
+    local action = rule.action
+    if action == nil then return true end
+    if type(action) ~= "table" then return false end
+    return next(action) == nil
+end
+
 -- Is this condition the "variable is absent" form? Canonical shape is
 -- `{op = "isSet", negated = true}`; the ModSec-style legacy `{op = "!isSet"}`
 -- is still accepted on input and normalized later in the engine, so both are

--- a/kong/plugins/karna/modules/ka_global_rules.lua
+++ b/kong/plugins/karna/modules/ka_global_rules.lua
@@ -360,6 +360,13 @@ end
 -- carrying `rule_control` NEXT TO a real action stays in detection, because
 -- the controls path deliberately does not run action side effects
 -- (set_variable / set_log_fields / redis_incr_key would be silently lost).
+--
+-- Duplicated on purpose: `ka_compile.is_control_only` is the canonical copy and
+-- is what handler.lua uses to split the per-plugin dynamic rules. This module
+-- deliberately requires neither ka_compile nor the engine (both are injected via
+-- init()) so it stays requirable from plain-Lua unit tests, so it carries its
+-- own. The two MUST stay in lockstep — a rule has to be filed the same way
+-- whichever channel it arrives on. Covered by ka-unittest/custom_secrules_split.lua.
 local function is_control_only(rule)
     if type(rule.rule_control) ~= "table" then return false end
     local action = rule.action

--- a/kong/plugins/karna/modules/seclang.lua
+++ b/kong/plugins/karna/modules/seclang.lua
@@ -617,6 +617,32 @@ function seclang.__get_phase(actions)
     end
 end
 
+-- Does a match on this rule earn an audit-log entry? `handler.lua` gates the
+-- record on `rule.log`, and the CRS loader sets it for every rule it loads
+-- (`ka_engine.lua:531`). Rules arriving through `parse_isolated` — inline
+-- `custom_secrules` and the CRS exclusion-plugin files — never went through that
+-- loader, so they matched, acted, and left no trace.
+--
+-- ModSec spelling: `nolog` suppresses logging, `auditlog` forces the audit log,
+-- and CRS writes `nolog,auditlog` to mean "no error log, yes audit log". Karna
+-- has only the audit log, so `auditlog` wins over `nolog` and the default is on.
+-- Matched on comma boundaries, the same convention `__get_action` uses for
+-- block/deny: the actions string also carries `msg:'…'` and `logdata:'…'`, whose
+-- free text must not be mistaken for a flag. `noauditlog` is tested before
+-- `auditlog` because it contains it.
+function seclang.__get_log(actions)
+    -- Pad with commas so a flag is found the same way at any position, and use a
+    -- plain (non-pattern) find since these flags carry no magic characters.
+    local padded = "," .. (actions or "") .. ","
+    local function has(flag)
+        return string.find(padded, "," .. flag .. ",", 1, true) ~= nil
+    end
+    if has("noauditlog") then return false end
+    if has("auditlog") then return true end
+    if has("nolog") then return false end
+    return true
+end
+
 function seclang.__get_message(actions)
     local msg = actions:match("msg:'([^']+)'")
     if msg then
@@ -874,6 +900,7 @@ function seclang.__parse_rule(rule_raw, chained, filter_by_id)
             action = seclang.__get_action(actions),
             message = seclang.__get_message(actions),
             logdata = seclang.__get_logdata(actions),
+            log = seclang.__get_log(actions),
             paranoia_level = "1"
         }
     end

--- a/kong/plugins/karna/schema.lua
+++ b/kong/plugins/karna/schema.lua
@@ -178,11 +178,20 @@ local schema = {
           { crs_plugins_enabled = { type = "array", elements = { type = "string" }, default = {} } },
 
           -- Inline SecLang rule strings. Each entry is a single SecRule
-          -- (or chained block) in ModSec syntax. Parsed via seclang at
-          -- init_worker and added to the global rule pool. Use it for
-          -- one-off exclusions or custom detection without dropping a
-          -- .conf file on disk. JSON local rules in `rules_request`
-          -- remain available for the same purpose; the two coexist.
+          -- (or chained block) in ModSec syntax. Use it for one-off
+          -- exclusions or custom detection without dropping a .conf file
+          -- on disk. JSON local rules in `rules_request` remain available
+          -- for the same purpose; the two coexist.
+          --
+          -- Parsed once per (worker, plugin_conf) and pre-split into the two
+          -- evaluator paths, the same way the global rules pack is: a rule
+          -- carrying only `ctl:*` / `setvar:*` goes on the multi-match
+          -- controls path, and a rule with a disruptive action (`block` /
+          -- `deny`) on the standard first-terminal-match-wins path. Both run
+          -- BEFORE global, local and CRS rules, so an inline rule written for
+          -- this specific service wins over the shipped packs and its
+          -- exclusions land in time to affect everything after it.
+          -- `phase:1`/`phase:2` run in access, `phase:3` in header_filter.
           { custom_secrules = { type = "array", elements = { type = "string" }, default = {} } },
 
           -- All custom rules live here regardless of phase; the engine


### PR DESCRIPTION
An inline `SecRule ... "id:10000327,phase:1,block"` in `custom_secrules` was parsed, evaluated on every request, matched — and did nothing.

## The bug

Rules from this channel (and from the CRS exclusion-plugin `.conf` files) were handed to a single evaluator, `apply_pass_rule_controls`, which deliberately ignores `fixed_response` because it exists to collect `ctl:*` side effects:

```
handler.lua:848  local plugin_dyn_rules = get_plugin_dynamic_rules(plugin_conf)
handler.lua:849  apply_pass_rule_controls(plugin_conf, plugin_dyn_rules, "access")
```

Those were the only two references. Nothing ever passed them to `loop_rules`. `schema.lua` described the intended behaviour ("added to the global rule pool. Use it for one-off exclusions or custom detection") but nothing wired it up.

Nothing was wrong with the parsed rule: `REQUEST_URI` maps to `request.path_with_query`, `phase:1` maps to access, and `__get_action` already emits `fixed_response` for both `block` and `deny`. CRS rules come out of the same parser and do block.

## The fix

The channel is pre-split into `controls` and `detection`, reusing the classifier the global rules pack already uses — `rule_control` with no action goes to controls, anything with a real action to detection, so a rule carrying `rule_control` next to `setvar` / `set_variable` does not lose its side effects. `is_control_only` moved to `ka_compile` as the canonical copy; `ka_global_rules` keeps its duplicate because it must stay requirable without ka_compile (engine/compile refs are injected via `init()` for plain-Lua unit tests), and the lockstep requirement is now documented on both.

Cost: the split is computed once per (worker, plugin_conf) and cached with the parse — Kong hands out a new `plugin_conf` table on every Admin API write, so the cache invalidates itself. Net throughput is neutral to positive: these rules were already being evaluated on every request, just to no purpose. The controls half costs what it did before; the detection half now runs on the first-terminal-match-wins path, which can exit early where the multi-match path could not.

Precedence: detection runs in the same slot as its own exclusions, ahead of global, local and CRS rules. A rule an operator wrote by hand for one service wins over the shipped packs.

`phase:3` rules from this channel now run. seclang has always mapped `phase:3` to header_filter, but the channel was only evaluated in access, so such a rule did nothing at all.

## Second fix, found while testing

A matching rule blocked but left no audit-log entry. The log phase gates each record on `rule.log`, and only the CRS loader set it (`ka_engine.lua:531`) — rules parsed through `seclang.parse_isolated` never went through that loader. seclang now reads ModSec's logging flags off the action list: `auditlog` on, `noauditlog` off (tested first, since `auditlog` is a substring of it), `nolog` off, default on. `nolog,auditlog` logs, since the audit log is the only log Karna has. Flags are matched on comma boundaries so the free text in `msg:'…'` and `logdata:'…'` is not read as a flag.

## Verification

Measured on a live Kong with the reporter's exact rule:

| | before | after |
|---|---|---|
| `GET /pippo/x` | 200 | 403, `x-karna-rule-id: 10000327` |
| `GET /altro` | 200 | 200 |
| audit log v2 | no entry | `10000327 \| Test Rule \| block \| ['custom-rule']` |
| audit log v1 (+modsec) | no entry | `messages[]` with ruleId, tags, message, data |
| `nolog` without `auditlog` | — | blocks, no match entry |

Exclusions still work on the controls path: with a `ctl:ruleRemoveById=941100` rule, `/noskip` matches 941100 and `/skipme` matches 941110 — the removal applies only where it should.

- CRS regression **2757/2757 (100%)**, unchanged.
- `ka-unittest/custom_secrules_split.lua` — classifier truth table both copies must implement, bucketing (author order preserved, unevaluated phases dropped), and the logging flags including the honest limit that a `,flag,` inside a `msg` does match. Wired into CI.
- `ka-integration-tests/001_negated_isset_bypass.sh` re-run: 38 pass, 0 fail.

No version bump here — the entries sit under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwkrjSPN2Rh8WRQSCEDCER