### PR TITLE
release: v1.5.2 — !isSet fires on absence, custom_secrules can block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-11
+
 ### Fixed
 
 - An inline `custom_secrules` rule with a disruptive action never blocked. Rules
@@ -844,7 +846,8 @@ Core Rule Set. It needs no other plugin to work.
   inspected by default (set it to `true` to bypass trusted internal ranges).
 - The PL1 OWASP CRS regression suite passes at 100%.
 
-[Unreleased]: https://github.com/sicuranext/karna/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/sicuranext/karna/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/sicuranext/karna/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/sicuranext/karna/compare/v1.5.0...v1.5.1
 [1.1.5]: https://github.com/sicuranext/karna/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/sicuranext/karna/compare/v1.1.3...v1.1.4

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,11 +114,11 @@ ARG KARNA_COMMIT=unknown
 ARG KARNA_BUILD_DATE=unknown
 
 COPY kong/ /tmp/karna/kong/
-COPY kong-plugin-karna-1.5.1-0.rockspec /tmp/karna/
+COPY kong-plugin-karna-1.5.2-0.rockspec /tmp/karna/
 RUN set -eux; \
     cd /tmp/karna; \
     short="$(printf '%s' "$KARNA_COMMIT" | cut -c1-7)"; \
-    printf 'return {\n  version      = "1.5.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+    printf 'return {\n  version      = "1.5.2",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
         "$KARNA_COMMIT" "$short" "$KARNA_BUILD_DATE" > kong/plugins/karna/version.lua; \
     luarocks make; \
     cd /; \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -139,7 +139,7 @@ services:
       # RE2 spike: C source compiled to libka_re2.so at start (memory karna-re2-spike).
       - ../src:/usr/local/kong/custom-plugins/karna/src:ro
       - ../tests:/usr/local/kong/custom-plugins/karna/tests:ro
-      - ../kong-plugin-karna-1.5.1-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.5.1-0.rockspec:ro
+      - ../kong-plugin-karna-1.5.2-0.rockspec:/usr/local/kong/custom-plugins/karna/kong-plugin-karna-1.5.2-0.rockspec:ro
       - ./main-env.conf:/etc/kong/nginx/main-env.conf:ro
       # Pairs with KARNA_GLOBAL_RULES_PATH above (both commented out by default).
       # - ./global-rules.d:/etc/kong/karna/global-rules.d:ro

--- a/kong-plugin-karna-1.5.2-0.rockspec
+++ b/kong-plugin-karna-1.5.2-0.rockspec
@@ -1,13 +1,13 @@
 package = "kong-plugin-karna"
 
-version = "1.5.1-0"
+version = "1.5.2-0"
 
 local pluginName = package:match("^kong%-plugin%-(.+)$")
 
 supported_platforms = {"linux"}
 source = {
   url = "git+https://github.com/sicuranext/karna.git",
-  tag = "v1.5.1"
+  tag = "v1.5.2"
 }
 
 description = {

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -1,6 +1,6 @@
 local plugin = {
   PRIORITY = 8300,
-  VERSION = "1.5.1",
+  VERSION = "1.5.2",
 }
 
 local ngx                 = ngx

--- a/kong/plugins/karna/version.lua
+++ b/kong/plugins/karna/version.lua
@@ -10,7 +10,7 @@
 -- `version` is the single source of truth for the engine version and must stay
 -- in sync with the rockspec version and handler.lua's plugin.VERSION on release.
 return {
-  version      = "1.5.1",
+  version      = "1.5.2",
   commit       = "unknown",
   commit_short = "unknown",
   built_at     = "unknown",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -84,7 +84,7 @@ if have git && git -C "$REPO_ROOT" rev-parse HEAD >/dev/null 2>&1; then
   KA_SHORT="$(printf '%s' "$KA_COMMIT" | cut -c1-7)"
   KA_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
   log "Stamping version.lua (commit ${KA_SHORT})"
-  printf 'return {\n  version      = "1.5.1",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
+  printf 'return {\n  version      = "1.5.2",\n  commit       = "%s",\n  commit_short = "%s",\n  built_at     = "%s",\n}\n' \
     "$KA_COMMIT" "$KA_SHORT" "$KA_DATE" > "$REPO_ROOT/kong/plugins/karna/version.lua"
 fi
 


### PR DESCRIPTION
Two rule-channel correctness fixes, both cases where a rule an operator wrote looked armed and did nothing.

## What's in it

**`isSet` with `negated: true` now fires on a missing variable** (#43). The documented way to spell "this variable is absent" never worked: the rule-control removal block collapses an emptied values table to `nil`, so the branch that handled absence was unreachable. An access-control rule ("deny unless this API key header is present") matched nothing and allowed everything. Absence is now distinguished from a ctl-excluded target, from an unreadable Redis key, and from Redis inspection being switched off — the last two are "unknown" and honour `redis_on_error` in terms of the rule's decision, so an allowlist rule no longer turns a Redis outage into a total outage. A rule carrying both `rule_control` and a negated `isSet` is refused at load.

**`custom_secrules` with a disruptive action now blocks** (#44). Rules from that channel went to the multi-match controls path only, which ignores `fixed_response`, so an inline `SecRule ... "block"` was parsed, evaluated on every request, matched, and had its terminal action discarded. The channel is now pre-split into controls and detection — computed once per (worker, plugin_conf) and cached with the parse, so no per-request cost. `phase:3` rules from this channel now run at all, and a matching rule finally reaches the audit log (only the CRS loader set `rule.log`), on both v1 and v2.

## Version bump

All six spots from CLAUDE.md plus the rockspec rename:

- `kong/plugins/karna/version.lua` — source of truth
- `kong/plugins/karna/handler.lua` — the `VERSION` placeholder
- rockspec `version` (`1.5.2-0`) and `source.tag` (`v1.5.2`)
- rockspec filename → `kong-plugin-karna-1.5.2-0.rockspec`
- `docker/Dockerfile` — the `COPY` line and the build-time `version.lua` stamp
- `docker/docker-compose.dev.yml` — the bind mount, both sides
- `scripts/install.sh` — its stamp

`grep -rn "1.5.1"` over sources is clean; 8 occurrences of `1.5.2` where expected. CHANGELOG entries moved under `[1.5.2] - 2026-08-11` with a fresh compare link.

## Verification

- CRS regression **2757/2757 (100%)** on both fixes.
- `ka-integration-tests/001_negated_isset_bypass.sh` — 38 pass, 0 fail, incl. the Redis outage matrix.
- New unit tests `negated_isset_absence.lua` and `custom_secrules_split.lua`, both wired into CI.

Note for whoever recreates a dev stack on this commit: the rockspec rename invalidates the old bind mount, so an existing `karna-kong` container needs `up -d --force-recreate kong` rather than a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwkrjSPN2Rh8WRQSCEDCER