### PR TITLE
fix(handler): initialise the request context before access can exit early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- The access phase now initialises its per-request context before anything can
+  leave the function. It has four early exits — the sibling-cache short-circuit,
+  the reserved `/.well-known/karna` self-identification path, the profiling
+  trigger, and the `ignore_from_local_ips` skip — and each returned with
+  `kong.ctx.plugin` still empty, while `header_filter`, `body_filter` and `log`
+  ran anyway, for this plugin and for every other plugin in the chain. Karna's own
+  later phases are nil-guarded, so a Karna-only deployment never noticed. A chained
+  deployment can, and the symptom is both ugly and hard to trace: no response
+  headers at all, the connection dies (`INTERNAL_ERROR` on HTTP/2, a plain reset or
+  a hang on HTTP/1.1), and only ever on the one path that exits early — which reads
+  like a protocol problem rather than a state problem. Every other terminal path (a
+  rule block, the rate-limit 429) already ran well past the initialisation, which
+  is why blocking worked while the identification endpoint did not. Initialising
+  first costs four empty tables and one boolean, and makes the invariant simple:
+  whatever happens next, the context exists. `rule_controls` is deliberately NOT
+  hoisted — it is created after the always-on validation gates precisely so no
+  `ctl:*` directive can switch them off, and that ordering is a security property.
+  CRS regression 2757/2757, unchanged.
+
 ## [1.5.2] - 2026-08-11
 
 ### Fixed

--- a/kong/plugins/karna/handler.lua
+++ b/kong/plugins/karna/handler.lua
@@ -688,6 +688,27 @@ function plugin:init_worker()
 end
 
 function plugin:access(plugin_conf)
+  -- Per-request scratch context, initialised BEFORE anything can leave this
+  -- function. `access` has four early exits — the cache short-circuit below, the
+  -- self-identification path, the profiling trigger, and the local-IP skip — and
+  -- all of them used to return with `kong.ctx.plugin` still empty while
+  -- `header_filter`, `body_filter` and `log` ran anyway, for this plugin and for
+  -- every other plugin in the chain. Karna's own later phases are nil-guarded, so
+  -- a Karna-only deployment never noticed; a chained one can, and the symptom is
+  -- ugly and hard to trace (no response headers, the stream dies, only on the one
+  -- path that exits early). Initialising first costs four empty tables and makes
+  -- the invariant simple: whatever happens next, the context exists.
+  --
+  -- Deliberately NOT hoisted: `kong.ctx.plugin.rule_controls`, which is created
+  -- after the always-on validation gates precisely so no `ctl:*` directive can
+  -- switch them off. See the comment at its assignment below.
+  kong.ctx.plugin.ka_value_cache = {}
+  kong.ctx.plugin.ka_variable_cache = {}
+  kong.ctx.plugin.ka_matched_rules = {}
+  kong.ctx.plugin.rule_variables = {}
+  -- Variables that can be overwritten by rules
+  kong.ctx.plugin.enable_check_arg_len = true
+
   -- skip access phase if response sent from cache
   if kong.ctx.shared.response_from_cache then
     return
@@ -744,9 +765,7 @@ function plugin:access(plugin_conf)
     end
   end
 
-  -- value cache
-  kong.ctx.plugin.ka_value_cache = {}
-  kong.ctx.plugin.ka_variable_cache = {}
+  -- (ka_value_cache / ka_variable_cache initialised at the top of this function)
 
   -- MCP detection + JSON-RPC envelope parsing. No-op when mcp_enabled=false.
   -- Populates kong.ctx.plugin.mcp consumed later by the variable resolver
@@ -756,11 +775,8 @@ function plugin:access(plugin_conf)
     ka_mcp.parse_request(plugin_conf)
   end
 
-  -- Rule Evaluation (access phase)
-  kong.ctx.plugin.ka_matched_rules = {}
-
-  -- Variables that can be overwritten by rules
-  kong.ctx.plugin.enable_check_arg_len = true
+  -- Rule Evaluation (access phase). ka_matched_rules and enable_check_arg_len
+  -- are initialised at the top of this function.
 
   -- check if method is allowed
   engine:method_allowed(plugin_conf)
@@ -792,8 +808,7 @@ function plugin:access(plugin_conf)
   -- can't pin the worker.
   local ka_arg_limit_exceeded = engine:check_request_arg_count(plugin_conf)
 
-  -- set local variables
-  kong.ctx.plugin.rule_variables = {}
+  -- (rule_variables initialised at the top of this function)
 
   -- set transaction variables (for setvar support + CRS-setup-style
   -- config knobs). Karna users configure via plugin_conf; we mirror the


### PR DESCRIPTION
`GET /.well-known/karna` on a chained deployment killed the connection — `HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR`, no response headers at all — while every other path on the same host worked, blocking included.

## What it is not

Measured against the live deployment before touching anything:

| test | result |
|---|---|
| `/.well-known/karna` over HTTP/1.1 | fails |
| `/.well-known/karna` over HTTP/2 | fails |
| `HEAD` on the same path | fails |
| other `/.well-known/*` paths | 404 / 301, normal |
| `/` | 200 |
| an XSS payload on `/` | 403, Karna blocking fine |
| both load-balancer backends | fail identically |
| same path, same Karna version, standalone stack, h1 and h2 | **200** |

So: not HTTP/2, not the `/.well-known/` prefix, not the load balancer, not one bad node, not the response body (`HEAD` fails too), and not a bug that reproduces on a Karna-only stack.

## What it is

`plugin:access` has four early exits:

- the `response_from_cache` short-circuit
- the reserved `/.well-known/karna` self-identification path
- the profiling trigger
- the `ignore_from_local_ips` skip

Every one of them returned with `kong.ctx.plugin` still empty, because the per-request scratch tables were initialised further down. `header_filter`, `body_filter` and `log` run regardless — for this plugin and for every other plugin in the chain.

Karna's own later phases are nil-guarded, which is exactly why this stayed invisible: a Karna-only deployment never notices. Every other terminal path — a rule block, the rate-limit 429 — exits well past the initialisation, which is why blocking worked on the same host while the identification endpoint did not.

The failure mode is the worst kind to debug. No response headers, so there is nothing to read; the connection dies rather than erroring; and it happens on exactly one path, which makes it look like a protocol or routing problem instead of a state problem.

## The fix

Initialise `ka_value_cache`, `ka_variable_cache`, `ka_matched_rules`, `rule_variables` and `enable_check_arg_len` at the top of `access`, before anything can return. Four empty tables and a boolean, and the invariant becomes simple: whatever happens next, the context exists.

`kong.ctx.plugin.rule_controls` is deliberately **not** hoisted. It is created after the always-on validation gates precisely so no `ctl:*` directive can switch them off — that ordering is a security property, documented at its assignment.

Behaviour is otherwise unchanged: the short-circuits keep their relative order, so the reserved path still answers before the local-IP skip and still never reaches upstream.

## Verification

- `/.well-known/karna` → 200 with the identity JSON, over both HTTP/1.1 and HTTP/2.
- Normal traffic 200, XSS 403.
- CRS regression **2757/2757 (100%)**, unchanged.
- `ka-integration-tests/001_negated_isset_bypass.sh` — 38 pass, 0 fail.
- All unit tests pass.

The proximate crash on the chained deployment is in a sibling plugin's response phase, which I cannot read from here — the Kong host is not the one I have access to. What this PR fixes is the cause on Karna's side: it was the only path leaving `access` in a state no other path produces. Worth re-testing on that deployment to confirm the symptom is gone.

No version bump — the entry sits under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwkrjSPN2Rh8WRQSCEDCER