### PR TITLE
fix(engine): guard rule_controls in the ctl:* target-removal block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- A response-phase rule no longer crashes `header_filter` on a request whose access
+  phase exited early. `ka_engine`'s `ctl:*` target-removal block guarded
+  `kong.ctx.plugin` but then indexed `kong.ctx.plugin.rule_controls.…`, and that
+  store is created by `access` — which returns before it exists on four paths (the
+  sibling-cache short-circuit, the reserved `/.well-known/karna` path, the profiling
+  trigger, the `ignore_from_local_ips` skip). `header_filter` runs for those requests
+  anyway, so indexing a field of a nil store threw inside `header_filter`, where
+  nginx cannot turn the error into a response because the headers were never
+  flushed: the client got no status line at all, the connection hung for the proxy's
+  read timeout and then died (`INTERNAL_ERROR` on HTTP/2, a reset or a plain hang on
+  HTTP/1.1). Only on the one path that exits early, which reads like a protocol
+  fault rather than a nil field.
+  - Reproducing it needs a `header_filter`-phase rule, which a default configuration
+    does not have — that is why it showed up on a deployment carrying a converted
+    rule pack and not on a plain stack. Now pinned by `B12` in
+    `ka-integration-tests/001_negated_isset_bypass.sh`, which configures a
+    response-phase rule and then checks the reserved path and the local-IP skip.
+  - The store is still created after the always-on validation gates, not hoisted:
+    that ordering is what stops any `ctl:*` directive from switching those gates off.
+    The block now binds it once and treats "no store" as "no controls to apply".
+  - CRS regression 2757/2757, unchanged.
 - The access phase now initialises its per-request context before anything can
   leave the function. It has four early exits — the sibling-cache short-circuit,
   the reserved `/.well-known/karna` self-identification path, the profiling

--- a/ka-integration-tests/001_negated_isset_bypass.sh
+++ b/ka-integration-tests/001_negated_isset_bypass.sh
@@ -166,6 +166,30 @@ note "handler.lua short-circuits GET /.well-known/karna in access BEFORE the rul
 note "loop. It never reaches upstream, but an ACL cannot suppress it either."
 assert "[KNOWN]   B11 /.well-known/karna, no key" 200 "http://$PROXY/.well-known/karna"
 
+say "B12 — an early exit from access must not break the response phase"
+note "access returns before kong.ctx.plugin.rule_controls exists on four paths (the"
+note "sibling-cache short-circuit, this reserved path, the profiling trigger, the"
+note "ignore_from_local_ips skip), yet header_filter runs for those requests. A"
+note "response-phase rule then reached the ctl:* target-removal block and indexed a"
+note "field of a nil store: a hard error inside header_filter, which cannot become a"
+note "response because the headers were never flushed. The client got a hang and a"
+note "dead connection with no status line — only on that one path. Needs a"
+note "header_filter-phase rule to reproduce, which is why a default config missed it."
+B12=$(cat <<'JSON'
+{"id":"b12_hf","phase":"header_filter","message":"response-phase rule",
+ "conditions":[{"variables":["response.status"],"op":"eq","value":"999"}],
+ "action":{"fixed_response":{"status_code":418}}}
+JSON
+)
+configure "{\"coreruleset_enabled\":false,\"rules_request\":$(rules_json "$B12")}"
+assert "[GUARD]   B12a normal request, hf rule present"  200 "http://$PROXY/get"
+assert "[GUARD]   B12b reserved path, hf rule present"   200 "http://$PROXY/.well-known/karna"
+note "Same class, different early exit: with the local-IP skip on, access returns even"
+note "sooner. A request from a local IP must still complete."
+configure '{"ignore_from_local_ips":true}'
+assert "[GUARD]   B12c local-IP skip, hf rule present"   200 "http://$PROXY/get"
+configure '{"ignore_from_local_ips":false}'
+
 # ===========================================================================
 say "C — bypass: negated isSet on a rule carrying rule_control"
 note "THE vector the fix opens. A matching control rule applies its ctl:* side"

--- a/kong/plugins/karna/modules/ka_engine.lua
+++ b/kong/plugins/karna/modules/ka_engine.lua
@@ -3250,11 +3250,30 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
             end
 
             if kong.ctx and kong.ctx.plugin then
-                if values and #kong.ctx.plugin.rule_controls.remove_target_from_all_rules > 0 then
+                -- The ctl:* store is created by handler.lua:access, and access has
+                -- early exits that return before it exists — the sibling-cache
+                -- short-circuit, the reserved /.well-known/karna path, the
+                -- profiling trigger, the ignore_from_local_ips skip. `header_filter`
+                -- runs for those requests anyway, so a response-phase rule reached
+                -- this block with `rule_controls` nil and the two sub-blocks below
+                -- indexed a field of it: a hard error inside header_filter, which
+                -- nginx cannot turn into a response because the headers were never
+                -- flushed. The client saw the connection hang and die with no status
+                -- line at all — on exactly one path, which reads like a protocol
+                -- fault rather than a nil field.
+                --
+                -- Bound once and guarded here rather than initialised earlier in
+                -- access: the store is created AFTER the always-on validation gates
+                -- on purpose, so no ctl:* directive can switch them off, and that
+                -- ordering is a security property worth more than the two lines it
+                -- saves here. No store simply means no controls to apply.
+                local _rc = kong.ctx.plugin.rule_controls
+
+                if _rc and values and #_rc.remove_target_from_all_rules > 0 then
                     -- Drop every ctl-excluded target (ruleRemoveTargetByTag on
                     -- the OWASP_CRS tag → applies to all rules). Name-based +
                     -- namespace-gated match (see remove_ctl_target).
-                    for _,remove_target in pairs(kong.ctx.plugin.rule_controls.remove_target_from_all_rules) do
+                    for _,remove_target in pairs(_rc.remove_target_from_all_rules) do
                         remove_ctl_target(values, remove_target, variable)
                     end
                     if next(values) == nil then values = nil end
@@ -3264,9 +3283,9 @@ _M.__match_rule_conditions_impl = function(self, rule, plugin_conf)
                 -- populates rule_controls.ids_targets[<id>] = { target1, target2, ... }
                 -- in handler.lua when a plugin rule fires. Drop those target
                 -- entries from `values` so the current rule never sees them.
-                if values and kong.ctx.plugin.rule_controls.ids_targets
-                   and kong.ctx.plugin.rule_controls.ids_targets[rule.id] then
-                    for _, t in pairs(kong.ctx.plugin.rule_controls.ids_targets[rule.id]) do
+                if _rc and values and _rc.ids_targets
+                   and _rc.ids_targets[rule.id] then
+                    for _, t in pairs(_rc.ids_targets[rule.id]) do
                         remove_ctl_target(values, t, variable)
                     end
                     if next(values) == nil then values = nil end


### PR DESCRIPTION
The real cause of `GET /.well-known/karna` hanging on the production chain. #46 addressed a related defect but not this one, and the mechanism I predicted there was wrong: this is a hard Lua error, not a missing-context read.

## The error

Straight from the production Kong pod:

```
failed to run header_filter_by_lua*:
/usr/local/share/lua/5.1/kong/plugins/karna/ka_engine.lua:3253:
attempt to index field 'rule_controls' (a nil value)
    ...
    header_filter_by_lua(nginx-kong.conf:139):2: in main chunk,
    request: "GET /.well-known/karna HTTP/2.0", host: "blog.sicuranext.com"
```

## Why it looked like a protocol problem

The `ctl:*` target-removal block guarded `kong.ctx.plugin` and then indexed `kong.ctx.plugin.rule_controls.remove_target_from_all_rules`. That store is created by `handler:access`, which returns **before** it exists on four paths: the sibling-cache short-circuit, the reserved `/.well-known/karna` path, the profiling trigger, and the `ignore_from_local_ips` skip. `header_filter` runs for those requests anyway.

Throwing inside `header_filter` is the worst place for it: nginx cannot turn the error into a 500 because the response headers were never flushed. So the client gets no status line at all, the connection hangs until the proxy read timeout, then dies — `INTERNAL_ERROR` on HTTP/2, a reset or a plain hang on HTTP/1.1. On exactly one path. That reads like HTTP/2, or the load balancer, or routing — anything but a nil field.

What the black-box evidence said before I had the log: the path never reached the upstream (every variation of it did — `karnax`, `karn`, `KARNA`, `karna/` all got 301/404 from Ghost, the exact path never appeared), both LB nodes failed identically, `HEAD` failed too, and both HTTP versions failed at a clean ~30s.

## Why it never reproduced locally

It needs a `header_filter`-phase rule to reach `__match_rule_conditions` in that phase. A default configuration has none, so a plain stack answers the reserved path in microseconds. The affected deployment carries a converted rule pack that includes response-phase rules.

Reproduced locally once I added one, with the identical error, then confirmed fixed:

| | before | after |
|---|---|---|
| `GET /get` (hf rule present) | 200 | 200 |
| `GET /.well-known/karna` (hf rule present) | hang, 000 | 200 in 4ms |
| same over HTTP/2 + TLS | hang | 200 |
| local-IP skip, hf rule present | hang | 200 |

## The fix

Bind the store once and guard it. "No store" means "no controls to apply", which is the correct reading.

It is deliberately **not** hoisted into the early part of `access`: `rule_controls` is created after the always-on validation gates precisely so no `ctl:*` directive can switch them off, and that ordering is a security property worth more than the two lines it would save.

## Verification

- CRS regression **2757/2757 (100%)**, unchanged.
- Integration suite **41 pass, 0 fail** — new group `B12` configures a response-phase rule and then checks the reserved path and the local-IP skip, so the regression is pinned where a reader will find it.
- `rule_control_runtime.lua`, `wordpress_target_exclusion.lua` and the rest of the unit tests pass, so the ctl:* exclusion behaviour itself is unchanged.

No version bump — the entry sits under `[Unreleased]` next to #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwkrjSPN2Rh8WRQSCEDCER